### PR TITLE
Fixed dynamic linkage for real libcxl

### DIFF
--- a/software/tools/Makefile
+++ b/software/tools/Makefile
@@ -23,7 +23,7 @@ LDLIBS += $(libs) -lpthread
 ifdef BUILD_SIMCODE
 libs += ../../pslse/libcxl/libcxl.a
 else
-libs += -lcxl
+LDLIBS += -lcxl
 endif
 
 dnut_peek_objs = force_cpu.o


### PR DESCRIPTION
Signed-off-by: Frank Haverkamp haver@linux.vnet.ibm.com
