### PR TITLE
Stage2 add on

### DIFF
--- a/software/tools/stage2.c
+++ b/software/tools/stage2.c
@@ -252,7 +252,7 @@ static int memcpy_test(struct dnut_card* dnc,
 	/* Memcpy */
 	for (i = 0; i < iter; i++) {
 		action_memcpy(dnc, mode, dest, src, block4k);
-		//action_wait_idle(dnc, 1000);
+		action_wait_idle(dnc, 1000);
 		if (ACTION_CONFIG_COPY_HH == mode) {
 			rc = memcmp(src, dest, block4k);
 			if (rc) break;
@@ -277,7 +277,7 @@ static int memcpy_test(struct dnut_card* dnc,
 			}
 		}
 	}
-	if ((ACTION_CONFIG_COPY_HH == mode) && (0 != rc)) {
+	if (ACTION_CONFIG_COPY_HH == mode) {
 		for (i = 0; i < block4k; i++) {
 			if (src[i] != dest[i])
 				printf("Error offset: %d: SRC: %x Dest: %x\n",


### PR DESCRIPTION
This example test code is used for bringup more DMA functions.
I added code to test 5 Actions. Action 1+2 
1.) Count Action
2.) from Host to Host Mem
3.) from Host Mem to DDR Mem
4.) from DDR Mem to Host Mem
5.) from DDR Mem to DDR Mem
DDR Mem is the Memory on the FPGA Card. The new functions are now
enabled by option "-a" for Action. For more details see "-h" option. 
