### PR TITLE
USE PSLSE_DIR in the tools and examples Makefiles.

### DIFF
--- a/software/examples/Makefile
+++ b/software/examples/Makefile
@@ -21,7 +21,7 @@ libs = ../lib/libdonut.a
 LDLIBS += $(libs) -lpthread
 
 ifdef BUILD_SIMCODE
-libs += ../../../pslse/libcxl/libcxl.a
+libs += $(PSLSE_DIR)/libcxl/libcxl.a
 else
 LDLIBS += -lcxl
 endif

--- a/software/tools/Makefile
+++ b/software/tools/Makefile
@@ -21,7 +21,7 @@ libs = ../lib/libdonut.a
 LDLIBS += $(libs) -lpthread
 
 ifdef BUILD_SIMCODE
-libs += ../../../pslse/libcxl/libcxl.a
+libs += $(PSLSE_DIR)/libcxl/libcxl.a
 else
 LDLIBS += -lcxl
 endif


### PR DESCRIPTION
I noticed that the Makefiles in both `software/examples` and `software/tools` included hardcoded paths to the pslse, which didn't work in our build environment. 

This change reuses the `PSLSE_DIR` defined in `software/config.mk` instead of the hardcoded path. 
