### PR TITLE
axi_clock_converter XDCs need a set_clock_groups

### DIFF
--- a/hardware/hdl/psl_accel_syn.vhd
+++ b/hardware/hdl/psl_accel_syn.vhd
@@ -670,7 +670,6 @@ BEGIN
   --                                                                                     -- only for DDR3_USED=TRUE
   --                                                                                     -- only for DDR3_USED=TRUE
   --                                                                                     -- only for DDR3_USED=TRUE
-  c0_ddr3_dm <= (others => '0');                                                         -- only for DDR3_USED=TRUE
   c1_ddr3_dm <= (others => '0');                                                         -- only for DDR3_USED=TRUE
 
   donut_i: donut

--- a/hardware/setup/donut.xdc
+++ b/hardware/setup/donut.xdc
@@ -6,6 +6,8 @@ resize_pblock [get_pblocks donut] -add {CLOCKREGION_X3Y3:CLOCKREGION_X5Y3}
 
 create_generated_clock   -name ha_pclock  [get_pins b/pcihip0/psl_pcihip0_inst/inst/gt_top_i/phy_clk_i/bufg_gt_userclk/O]
 
+set_clock_groups -name clkddr_2_clkpsl -asynchronous -group [get_clocks mmcm_clkout0] -group [get_clocks ha_pclock]
+
 set_max_delay -from [get_pins a0/*ddr3_reset_n_q_reg/C] -to [get_pins  a0/*ddr3sdram_bank1/inst/u_ddr_axi/areset_d1_reg/D]  3.0
 set_min_delay -from [get_pins a0/*ddr3_reset_n_q_reg/C] -to [get_pins  a0/*ddr3sdram_bank1/inst/u_ddr_axi/areset_d1_reg/D] -0.5
 


### PR DESCRIPTION
Signed-off-by: Thomas Fuchs <thomas.fuchs@de.ibm.com>