### PR TITLE
timing solution for the axi_clock_converter timing issue

### DIFF
--- a/hardware/setup/create_framework.tcl
+++ b/hardware/setup/create_framework.tcl
@@ -117,16 +117,25 @@ update_compile_order -fileset sources_1
 
 # IMPORT PSL CHECKPOINT FILE
 read_checkpoint -cell b $build_dir/Checkpoint/b_route_design.dcp -strict
-#add_files -norecurse $build_dir/Checkpoint/b_route_design.dcp
+add_files -fileset constrs_1 -norecurse $root_dir/setup/donut_synth.xdc
+set_property used_in_implementation false [get_files   $root_dir/setup/donut_synth.xdc]
+add_files -fileset constrs_1 -norecurse $root_dir/setup/donut_link.xdc
+set_property used_in_synthesis false [get_files  $root_dir/setup/donut_link.xdc]
 update_compile_order -fileset sources_1
-add_files -fileset constrs_1 -norecurse $root_dir/setup/donut.xdc
+
+set_property used_in_synthesis false [get_files  /afs/bb/proj/fpga/framework/cards/dimm_test-admpcieku3-v3_0_0/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_dm_b1_x72ecc.xdc]
+set_property used_in_synthesis false [get_files  /afs/bb/proj/fpga/framework/cards/dimm_test-admpcieku3-v3_0_0/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_locs_b1_8g_x72ecc.xdc]
 
 # IMPORT DDR3 XDCs
 if { $ddr3_used == TRUE } {
-  add_files -fileset constrs_1 -norecurse $dimm_dir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_dm_b0_x72ecc.xdc
+#  add_files -fileset constrs_1 -norecurse $dimm_dir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_dm_b0_x72ecc.xdc
+#  set_property used_in_synthesis false [get_files $dimm_dir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_dm_b0_x72ecc.xdc]
+#  add_files -fileset constrs_1 -norecurse $dimm_dir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_locs_b0_8g_x72ecc.xdc
+#  set_property used_in_synthesis false [get_files $dimm_dir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_locs_b0_8g_x72ecc.xdc] 
   add_files -fileset constrs_1 -norecurse $dimm_dir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_dm_b1_x72ecc.xdc
-  add_files -fileset constrs_1 -norecurse $dimm_dir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_locs_b0_8g_x72ecc.xdc
+  set_property used_in_synthesis false [get_files $dimm_dir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_dm_b1_x72ecc.xdc]
   add_files -fileset constrs_1 -norecurse $dimm_dir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_locs_b1_8g_x72ecc.xdc
+  set_property used_in_synthesis false [get_files $dimm_dir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_locs_b1_8g_x72ecc.xdc]
 }
 
 # EXPORT SIMULATION

--- a/hardware/setup/donut_link.xdc
+++ b/hardware/setup/donut_link.xdc
@@ -1,0 +1,47 @@
+create_pblock donut
+add_cells_to_pblock [get_pblocks donut] [get_cells -quiet [list a0/donut_i]] -clear_locs
+resize_pblock [get_pblocks donut] -add {CLOCKREGION_X3Y3:CLOCKREGION_X5Y3}
+
+create_generated_clock   -name ha_pclock  [get_pins b/pcihip0/psl_pcihip0_inst/inst/gt_top_i/phy_clk_i/bufg_gt_userclk/O]
+
+set_max_delay -from [get_pins a0/*ddr3_reset_n_q_reg/C] -to [get_pins  a0/*ddr3sdram_bank1/inst/u_ddr_axi/areset_d1_reg/D]  3.0
+set_min_delay -from [get_pins a0/*ddr3_reset_n_q_reg/C] -to [get_pins  a0/*ddr3sdram_bank1/inst/u_ddr_axi/areset_d1_reg/D] -0.5
+
+set_max_delay -from [get_pins a0/*ddr3_reset_n_q_reg/C] -to [get_pins {a0/*ddr3sdram_bank1/inst/axi_ctrl_top_0/axi_ctrl_reg_bank_0/inst_reg[3].axi_ctrl_reg/data_reg*/S}]  3.0
+set_min_delay -from [get_pins a0/*ddr3_reset_n_q_reg/C] -to [get_pins {a0/*ddr3sdram_bank1/inst/axi_ctrl_top_0/axi_ctrl_reg_bank_0/inst_reg[3].axi_ctrl_reg/data_reg*/S}] -0.5
+
+###############################################################################################################
+
+#
+
+# SNO Addition - copy from axi_clock_converter_clocks.xdc
+
+#
+
+###############################################################################################################
+
+# Core-Level Timing Constraints for axi_clock_converter Component "axi_clock_converter"
+
+###############################################################################################################
+
+set axi_cc [get_cells -hier -filter "ref_name == axi_clock_converter"]
+
+set s_clk  [get_clocks -of_objects [get_pins ${axi_cc}/s_axi_aclk]]
+
+set m_clk  [get_clocks -of_objects [get_pins ${axi_cc}/m_axi_aclk]]
+
+set_max_delay -from [filter [all_fanout -from [get_pins ${axi_cc}/s_axi_aclk] -flat -endpoints_only] {IS_LEAF}] -to [filter [all_fanout -from [get_pins ${axi_cc}/m_axi_aclk] -flat -only_cells] {IS_SEQUENTIAL && (NAME !~ *dout_i_reg[*])}] -datapath_only [get_property -min PERIOD $s_clk]
+
+set_max_delay -from [filter [all_fanout -from [get_pins ${axi_cc}/m_axi_aclk] -flat -endpoints_only] {IS_LEAF}] -to [filter [all_fanout -from [get_pins ${axi_cc}/s_axi_aclk] -flat -only_cells] {IS_SEQUENTIAL && (NAME !~ *dout_i_reg[*])}] -datapath_only [get_property -min PERIOD $m_clk]
+
+#
+
+###############################################################################################################
+
+#
+
+# End SNO Addition
+
+#
+
+###############################################################################################################

--- a/hardware/setup/donut_synth.xdc
+++ b/hardware/setup/donut_synth.xdc
@@ -1,0 +1,1 @@
+create_clock -name ha_pclock -period 4 [get_pins a0/ha_pclock]

--- a/hardware/setup/patch_tcl.sh
+++ b/hardware/setup/patch_tcl.sh
@@ -5,6 +5,8 @@ sed -i '/set netlistDir/ a\
 set rootDir    \$::env(DONUT_HARDWARE_ROOT)\
 set dimmDir    \$::env(DIMMTEST)' $2
 
+sed -i 's/top    synth_options "-flatten_hierarchy rebuilt/top    synth_options "-flatten_hierarchy none/' $2
+
 sed -i '/top    synth_options/ a\
                                            \]' $2
 
@@ -29,9 +31,8 @@ set_attribute module \$top    ip            \[list \\' $2
 
 if [ $DDR3_USED == "TRUE" ]; then
 sed -i '/top    synth_options/ a\
-set_attribute module $top    xdc           \[list \\\
-                                            \$dimmDir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_locs_b1_8g_x72ecc.xdc \\\
-                                            \$dimmDir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_dm_b1_x72ecc.xdc \\\
+set_attribute module $top    synthXDC      \[list \\\
+                                             \$rootDir/setup/donut_synth.xdc \\\
                                            \]' $2
 fi
 
@@ -44,12 +45,14 @@ if [ $ILA_DEBUG == "TRUE" ]; then
 sed -i '/top      top/ a\
                                              \$rootDir/setup/debug.xdc \\' $2
 fi
+if [ $DDR3_USED == "TRUE" ]; then
+sed -i '/top      top/ a\
+                                             \$dimmDir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_locs_b1_8g_x72ecc.xdc \\\
+                                             \$dimmDir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_dm_b1_x72ecc.xdc \\' $2
+fi
 
 sed -i '/top      top/ a\
 set_attribute impl \$top      linkXDC       \[list \\\
-                                             \$rootDir/setup/donut.xdc \\' $2
-
-sed -i '/top      impl/ a\
-#set_attribute impl \$top      phys_options  "-force_replication_on_nets \[get_nets -hierarchical -top_net_of_hierarchical_group -filter { NAME =~  "\*action_reset\*" } \]"' $2
+                                             \$rootDir/setup/donut_link.xdc \\' $2
 
 sed -i 's/top      phys_directive Explore/top      phys_directive AggressiveExplore/' $2


### PR DESCRIPTION
added donut_syn.xdc and donut_link.xdc in psl_fpga.tcl, to fix timing problems with the axi_clock_converter

Signed-off-by: Thomas Fuchs <thomas.fuchs@de.ibm.com>