### PR TITLE
HW_FIX #118: …

### DIFF
--- a/hardware/hdl/dma.vhd
+++ b/hardware/hdl/dma.vhd
@@ -142,129 +142,129 @@ ARCHITECTURE dma OF dma IS
 
   --
   -- SIGNAL
-  SIGNAL ah_c_counter_q         : integer RANGE 0 TO 255;
-  SIGNAL ah_c_fsm_q             : AH_C_FSM_T;
-  SIGNAL ah_c_max_q             : std_ulogic_vector(7 DOWNTO 0);
-  SIGNAL ah_c_max_reached_q     : boolean;
-  SIGNAL ah_c_q                 : AH_C_T;
-  SIGNAL ah_c_rgate_q           : GATE_INDICATION_T;
-  SIGNAL ah_c_rsp_err_addr_p_q  : std_ulogic;
-  SIGNAL ah_c_rsp_err_addr_q    : std_ulogic_vector(63 DOWNTO 0);
-  SIGNAL ah_c_rsp_err_first_q   : boolean;
-  SIGNAL ah_c_rsp_err_type_q    : RSP_CODES_T;
-  SIGNAL ah_c_rsp_err_valid_q   : boolean;
-  SIGNAL ah_c_wgate_q           : GATE_INDICATION_T;
-  SIGNAL ah_rc_q                : AH_RWC_T;
-  SIGNAL ah_wc_q                : AH_RWC_T;
-  SIGNAL aln_db_wb_rdreq        : std_ulogic;
-  SIGNAL aln_rdata              : std_ulogic_vector(511 DOWNTO  0);
-  SIGNAL aln_rdata_e            : std_ulogic;
-  SIGNAL aln_rdata_p            : std_ulogic_vector(  7 DOWNTO  0);
-  SIGNAL aln_rdata_v            : std_ulogic;
-  SIGNAL aln_wbusy              : std_ulogic;
-  SIGNAL aln_wdata              : std_ulogic_vector(511 DOWNTO  0);
-  SIGNAL aln_wdata_be           : std_ulogic_vector( 63 DOWNTO  0);
-  SIGNAL aln_wdata_p            : std_ulogic_vector(  7 DOWNTO  0);
-  SIGNAL aln_wdata_v            : std_ulogic;
-  SIGNAL aln_wfsm_idle          : std_ulogic;
-  SIGNAL buf_rdata              : std_ulogic_vector(511 DOWNTO  0);
-  SIGNAL buf_rdata_e_q          : std_ulogic;
-  SIGNAL buf_rdata_p            : std_ulogic_vector(  7 DOWNTO  0);
-  SIGNAL buf_rdata_vld          : std_ulogic;
-  SIGNAL buf_rrdreq             : std_ulogic;
-  SIGNAL buf_rtag_p_q           : std_ulogic;
-  SIGNAL buf_rtag_q             : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL buf_rtag_valid_q       : boolean;
-  SIGNAL buf_wactive_q          : boolean;
-  SIGNAL buf_walmost_full_q     : std_ulogic;
-  SIGNAL buf_wdata_parity_err   : std_ulogic;
-  SIGNAL buf_wfull_cnt_q        : integer RANGE 0 TO 32;
-  SIGNAL buf_wtag_p_q           : std_ulogic;
-  SIGNAL buf_wtag_q             : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL buf_wtag_hold_q        : integer RANGE 0 TO 31;
-  SIGNAL buf_wtag_cl_partial_q  : boolean;
+  SIGNAL ah_c_counter_q              : integer RANGE 0 TO 255;
+  SIGNAL ah_c_fsm_q                  : AH_C_FSM_T;
+  SIGNAL ah_c_max_q                  : std_ulogic_vector(7 DOWNTO 0);
+  SIGNAL ah_c_max_reached_q          : boolean;
+  SIGNAL ah_c_q                      : AH_C_T;
+  SIGNAL ah_c_rgate_q                : GATE_INDICATION_T;
+  SIGNAL ah_c_rsp_err_addr_p_q       : std_ulogic;
+  SIGNAL ah_c_rsp_err_addr_q         : std_ulogic_vector(63 DOWNTO 0);
+  SIGNAL ah_c_rsp_err_first_q        : boolean;
+  SIGNAL ah_c_rsp_err_type_q         : RSP_CODES_T;
+  SIGNAL ah_c_rsp_err_valid_q        : boolean;
+  SIGNAL ah_c_wgate_q                : GATE_INDICATION_T;
+  SIGNAL ah_rc_q                     : AH_RWC_T;
+  SIGNAL ah_wc_q                     : AH_RWC_T;
+  SIGNAL aln_db_wb_rdreq             : std_ulogic;
+  SIGNAL aln_rdata                   : std_ulogic_vector(511 DOWNTO  0);
+  SIGNAL aln_rdata_e                 : std_ulogic;
+  SIGNAL aln_rdata_p                 : std_ulogic_vector(  7 DOWNTO  0);
+  SIGNAL aln_rdata_v                 : std_ulogic;
+  SIGNAL aln_wbusy                   : std_ulogic;
+  SIGNAL aln_wdata                   : std_ulogic_vector(511 DOWNTO  0);
+  SIGNAL aln_wdata_be                : std_ulogic_vector( 63 DOWNTO  0);
+  SIGNAL aln_wdata_p                 : std_ulogic_vector(  7 DOWNTO  0);
+  SIGNAL aln_wdata_v                 : std_ulogic;
+  SIGNAL aln_wfsm_idle               : std_ulogic;
+  SIGNAL buf_rdata                   : std_ulogic_vector(511 DOWNTO  0);
+  SIGNAL buf_rdata_e_q               : std_ulogic;
+  SIGNAL buf_rdata_p                 : std_ulogic_vector(  7 DOWNTO  0);
+  SIGNAL buf_rdata_vld               : std_ulogic;
+  SIGNAL buf_rrdreq                  : std_ulogic;
+  SIGNAL buf_rtag_p_q                : std_ulogic;
+  SIGNAL buf_rtag_q                  : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL buf_rtag_valid_q            : boolean;
+  SIGNAL buf_wactive_q               : boolean;
+  SIGNAL buf_walmost_full_q          : std_ulogic;
+  SIGNAL buf_wdata_parity_err        : std_ulogic;
+  SIGNAL buf_wfull_cnt_q             : integer RANGE 0 TO 32;
   SIGNAL buf_wtag_cl_partial_hold_q  : boolean;
-  SIGNAL buf_wtag_valid_q       : boolean;
-  SIGNAL buf_wtag_valid_hold_q  : boolean;
-  SIGNAL clt_rtag_next_q        : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL clt_rtag_p_q           : std_ulogic;
-  SIGNAL clt_rtag_q             : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL clt_wtag_next_q        : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL clt_wtag_p_q           : std_ulogic;
-  SIGNAL clt_wtag_q             : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL com_rtag_next_q        : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL com_rtag_p_q           : std_ulogic;
-  SIGNAL com_rtag_q             : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL com_rtag_qq            : integer RANGE 0 TO 31;
-  SIGNAL com_rtag_valid_q       : boolean;
-  SIGNAL com_wtag_next_q        : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL com_wtag_p_q           : std_ulogic;
-  SIGNAL com_wtag_q             : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL com_wtag_qq            : integer RANGE 0 TO 31;
-  SIGNAL com_wtag_valid_q       : boolean;
-  SIGNAL context_handle_q       : std_ulogic_vector(15 DOWNTO 0);
-  SIGNAL dmm_e_q                : DMM_E_T := (OTHERS => '0');
-  SIGNAL ha_c_q                 : HA_C_T;
-  SIGNAL ha_r_q                 : HA_R_T;
-  SIGNAL intreq_active_q        : boolean;
-  SIGNAL mmd_a_q                : MMD_A_T;
-  SIGNAL mmd_i_q                : MMD_I_T;
-  SIGNAL raddr_id_q             : std_ulogic_vector(C_S_AXI_ID_WIDTH-1 DOWNTO 0);
-  SIGNAL raddr_offset_p_q       : std_ulogic;
-  SIGNAL raddr_offset_q         : std_ulogic_vector( 12 DOWNTO  7);
-  SIGNAL raddr_p_q              : std_ulogic;
-  SIGNAL raddr_q                : std_ulogic_vector( 63 DOWNTO  7);
-  SIGNAL rclen_q                : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL read_ctrl_buf_full_q   : std_ulogic_vector( 31 DOWNTO  0);
-  SIGNAL read_ctrl_fsm_q        : READ_CTRL_FSM_T;
-  SIGNAL read_ctrl_q            : ARR_DMA_CTL_T;
-  SIGNAL read_ctrl_q_err_q      : std_ulogic_vector( 31 DOWNTO  0);
-  SIGNAL read_ctrl_rsp_rtag_q   : DMA_CTL_T;
-  SIGNAL read_fsm_req_q         : FSM_REQ_T;
-  SIGNAL read_rsp_err_addr_p_q  : std_ulogic;
-  SIGNAL read_rsp_err_addr_q    : std_ulogic_vector(63 DOWNTO 0);
-  SIGNAL read_rsp_err_first_q   : boolean;
-  SIGNAL read_rsp_err_type_q    : RSP_CODES_T;
-  SIGNAL read_rsp_err_valid_q   : boolean;
-  SIGNAL restart_active_q       : boolean;
-  SIGNAL rfifo_empty            : std_ulogic;
-  SIGNAL rfifo_empty_tmp        : std_ulogic;
-  SIGNAL force_rfifo_empty_q    : std_ulogic;
-  SIGNAL rfifo_full             : std_ulogic;
-  SIGNAL rfifo_prog_full        : std_ulogic;
-  SIGNAL rfifo_rd_rst_busy      : std_ulogic;
-  SIGNAL rfifo_rdata            : std_ulogic_vector(512 DOWNTO 0);
-  SIGNAL rfifo_wdata            : std_ulogic_vector(512 DOWNTO 0);
-  SIGNAL rfifo_wr_rst_busy      : std_ulogic;
-  SIGNAL rfifo_wr_in_process_q  : std_ulogic_vector(1 DOWNTO 0);
-  SIGNAL rsp_rtag_next_q        : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL rsp_rtag_p_q           : std_ulogic;
-  SIGNAL rsp_rtag_q             : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL rsp_rtag_qq            : integer RANGE 0 TO 31;
-  SIGNAL rsp_rtag_valid_q       : boolean;
-  SIGNAL rsp_wtag_next_q        : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL rsp_wtag_p_q           : std_ulogic;
-  SIGNAL rsp_wtag_q             : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL rsp_wtag_qq            : integer RANGE 0 TO 31;
-  SIGNAL rsp_wtag_valid_q       : boolean;
-  SIGNAL sd_c_q                 : SD_C_T;
-  SIGNAL waddr_id_q             : std_ulogic_vector(C_S_AXI_ID_WIDTH-1 DOWNTO 0);
-  SIGNAL waddr_offset_p_q       : std_ulogic;
-  SIGNAL waddr_offset_q         : std_ulogic_vector( 12 DOWNTO  7);
-  SIGNAL waddr_p_q              : std_ulogic;
-  SIGNAL waddr_q                : std_ulogic_vector( 63 DOWNTO  7);
-  SIGNAL wclen_q                : std_ulogic_vector(  5 DOWNTO  0);
-  SIGNAL wr_id_valid_q          : std_ulogic;
-  SIGNAL write_ctrl_fsm_q       : WRITE_CTRL_FSM_T;
-  SIGNAL write_ctrl_q           : ARR_DMA_CTL_T;
-  SIGNAL write_ctrl_q_err_q     : std_ulogic_vector( 31 DOWNTO  0);
-  SIGNAL write_ctrl_rsp_wtag_q  : DMA_CTL_T;
-  SIGNAL write_fsm_req_q        : FSM_REQ_T;
-  SIGNAL write_rsp_err_addr_p_q : std_ulogic;
-  SIGNAL write_rsp_err_addr_q   : std_ulogic_vector(63 DOWNTO 0);
-  SIGNAL write_rsp_err_first_q  : boolean;
-  SIGNAL write_rsp_err_type_q   : RSP_CODES_T;
-  SIGNAL write_rsp_err_valid_q  : boolean;
+  SIGNAL buf_wtag_cl_partial_q       : boolean;
+  SIGNAL buf_wtag_hold_q             : integer RANGE 0 TO 31;
+  SIGNAL buf_wtag_p_q                : std_ulogic;
+  SIGNAL buf_wtag_q                  : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL buf_wtag_valid_hold_q       : boolean;
+  SIGNAL buf_wtag_valid_q            : boolean;
+  SIGNAL clt_rtag_next_q             : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL clt_rtag_p_q                : std_ulogic;
+  SIGNAL clt_rtag_q                  : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL clt_wtag_next_q             : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL clt_wtag_p_q                : std_ulogic;
+  SIGNAL clt_wtag_q                  : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL com_rtag_next_q             : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL com_rtag_p_q                : std_ulogic;
+  SIGNAL com_rtag_q                  : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL com_rtag_qq                 : integer RANGE 0 TO 31;
+  SIGNAL com_rtag_valid_q            : boolean;
+  SIGNAL com_wtag_next_q             : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL com_wtag_p_q                : std_ulogic;
+  SIGNAL com_wtag_q                  : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL com_wtag_qq                 : integer RANGE 0 TO 31;
+  SIGNAL com_wtag_valid_q            : boolean;
+  SIGNAL context_handle_q            : std_ulogic_vector(15 DOWNTO 0);
+  SIGNAL dmm_e_q                     : DMM_E_T := (OTHERS => '0');
+  SIGNAL force_rfifo_empty_q         : std_ulogic;
+  SIGNAL ha_c_q                      : HA_C_T;
+  SIGNAL ha_r_q                      : HA_R_T;
+  SIGNAL intreq_active_q             : boolean;
+  SIGNAL mmd_a_q                     : MMD_A_T;
+  SIGNAL mmd_i_q                     : MMD_I_T;
+  SIGNAL raddr_id_q                  : std_ulogic_vector(C_S_AXI_ID_WIDTH-1 DOWNTO 0);
+  SIGNAL raddr_offset_p_q            : std_ulogic;
+  SIGNAL raddr_offset_q              : std_ulogic_vector( 12 DOWNTO  7);
+  SIGNAL raddr_p_q                   : std_ulogic;
+  SIGNAL raddr_q                     : std_ulogic_vector( 63 DOWNTO  7);
+  SIGNAL rclen_q                     : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL read_ctrl_buf_full_q        : std_ulogic_vector( 31 DOWNTO  0);
+  SIGNAL read_ctrl_fsm_q             : READ_CTRL_FSM_T;
+  SIGNAL read_ctrl_q                 : ARR_DMA_CTL_T;
+  SIGNAL read_ctrl_q_err_q           : std_ulogic_vector( 31 DOWNTO  0);
+  SIGNAL read_ctrl_rsp_rtag_q        : DMA_CTL_T;
+  SIGNAL read_fsm_req_q              : FSM_REQ_T;
+  SIGNAL read_rsp_err_addr_p_q       : std_ulogic;
+  SIGNAL read_rsp_err_addr_q         : std_ulogic_vector(63 DOWNTO 0);
+  SIGNAL read_rsp_err_first_q        : boolean;
+  SIGNAL read_rsp_err_type_q         : RSP_CODES_T;
+  SIGNAL read_rsp_err_valid_q        : boolean;
+  SIGNAL restart_active_q            : boolean;
+  SIGNAL rfifo_empty                 : std_ulogic;
+  SIGNAL rfifo_empty_tmp             : std_ulogic;
+  SIGNAL rfifo_full                  : std_ulogic;
+  SIGNAL rfifo_prog_full             : std_ulogic;
+  SIGNAL rfifo_rd_rst_busy           : std_ulogic;
+  SIGNAL rfifo_rdata                 : std_ulogic_vector(512 DOWNTO 0);
+  SIGNAL rfifo_wdata                 : std_ulogic_vector(512 DOWNTO 0);
+  SIGNAL rfifo_wr_in_process_q       : std_ulogic_vector(1 DOWNTO 0);
+  SIGNAL rfifo_wr_rst_busy           : std_ulogic;
+  SIGNAL rsp_rtag_next_q             : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL rsp_rtag_p_q                : std_ulogic;
+  SIGNAL rsp_rtag_q                  : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL rsp_rtag_qq                 : integer RANGE 0 TO 31;
+  SIGNAL rsp_rtag_valid_q            : boolean;
+  SIGNAL rsp_wtag_next_q             : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL rsp_wtag_p_q                : std_ulogic;
+  SIGNAL rsp_wtag_q                  : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL rsp_wtag_qq                 : integer RANGE 0 TO 31;
+  SIGNAL rsp_wtag_valid_q            : boolean;
+  SIGNAL sd_c_q                      : SD_C_T;
+  SIGNAL waddr_id_q                  : std_ulogic_vector(C_S_AXI_ID_WIDTH-1 DOWNTO 0);
+  SIGNAL waddr_offset_p_q            : std_ulogic;
+  SIGNAL waddr_offset_q              : std_ulogic_vector( 12 DOWNTO  7);
+  SIGNAL waddr_p_q                   : std_ulogic;
+  SIGNAL waddr_q                     : std_ulogic_vector( 63 DOWNTO  7);
+  SIGNAL wclen_q                     : std_ulogic_vector(  5 DOWNTO  0);
+  SIGNAL wr_id_valid_q               : std_ulogic;
+  SIGNAL write_ctrl_fsm_q            : WRITE_CTRL_FSM_T;
+  SIGNAL write_ctrl_q                : ARR_DMA_CTL_T;
+  SIGNAL write_ctrl_q_err_q          : std_ulogic_vector( 31 DOWNTO  0);
+  SIGNAL write_ctrl_rsp_wtag_q       : DMA_CTL_T;
+  SIGNAL write_fsm_req_q             : FSM_REQ_T;
+  SIGNAL write_rsp_err_addr_p_q      : std_ulogic;
+  SIGNAL write_rsp_err_addr_q        : std_ulogic_vector(63 DOWNTO 0);
+  SIGNAL write_rsp_err_first_q       : boolean;
+  SIGNAL write_rsp_err_type_q        : RSP_CODES_T;
+  SIGNAL write_rsp_err_valid_q       : boolean;
 
   --
   -- COMPONENT
@@ -1508,8 +1508,11 @@ BEGIN
           -- BUF: BUFFER TAG is valid
           --
           IF (buf_wtag_valid_q = TRUE) THEN
-
-            
+            --
+            -- Note: It could be that write_ctrl_q[n] for the last CL of a 4K AXI request
+            --       is NOT_USED, but the data were written in the CL buffer.
+            --       In such a case the update of the write_ctrl_q have to wait until
+            --       write_ctrl_q[n] is IN_USE
             IF (write_ctrl_q(buf_wtag_v).clt = IN_USE) THEN
               buf_wtag_valid_hold_q        <= FALSE;
               write_ctrl_q(buf_wtag_v).buf <= FULL;
@@ -1531,6 +1534,9 @@ BEGIN
           END IF;
 
 
+          --
+          -- update write_ctrl_q[n] unit it goes to IN_USE
+          -- 
           IF (buf_wtag_valid_hold_q = TRUE) THEN
             IF (write_ctrl_q(buf_wtag_hold_q).clt = IN_USE) THEN
 

--- a/hardware/hdl/dma_buffer.vhd
+++ b/hardware/hdl/dma_buffer.vhd
@@ -137,7 +137,6 @@ ARCHITECTURE dma_buffer OF dma_buffer IS
   SIGNAL wram_wdata                       : std_ulogic_vector(583 DOWNTO 0);
   SIGNAL wram_wen                         : std_ulogic;
   SIGNAL even_wdata_complete_q            : boolean;
-  SIGNAL odd_wdata_complete_q             : boolean;
   SIGNAL buf_wtag_cl_partial_q            : boolean;
   SIGNAL parity_error_fir_q               : std_ulogic := '0';
 
@@ -383,6 +382,10 @@ BEGIN
 --512            if  gen_parity_odd_128(buf_wdata_i) /= (buf_wdata_p_i xor buf_wdata_be_i) then
 --512              parity_error_fir_q <= '1';
 --512            end if;
+
+            --
+            -- check that the first 64 bytes of a CL are written into the buffer
+            -- 
             IF (wram_waddr_q(0) = '0') THEN
               IF (and_reduce(buf_wdata_be_i) = '1') THEN
                 even_wdata_complete_q <= TRUE;
@@ -391,6 +394,9 @@ BEGIN
               END IF;  
             END IF;
 
+            --
+            -- check that the second 64 bytes of a CL are written into the buffer
+            -- 
             IF (wram_waddr_q(0) = '1') THEN
               IF (and_reduce(buf_wdata_be_i) = '1') THEN
                 odd_wdata_complete_v := TRUE;
@@ -400,6 +406,9 @@ BEGIN
             END IF;
           end if;
 
+          --
+          -- check that the full CL is written into the buffer
+          -- 
           IF (even_wdata_complete_q = TRUE) AND
              (odd_wdata_complete_v  = TRUE) THEN
             buf_wtag_cl_partial_q <= FALSE;


### PR DESCRIPTION
Fix for defect #118 
The DMA write engine makes 2 times a read_lock + write_unlock at the beginning. Only one is necessary


Signed-off-by: Thomas Fuchs <thomas.fuchs@de.ibm.com>