### PR TITLE
The XDC files have had the wrong order in case of BRAM=TRUE

### DIFF
--- a/hardware/setup/patch_tcl.sh
+++ b/hardware/setup/patch_tcl.sh
@@ -60,12 +60,10 @@ done
 sed -i '/top    synth_options/ a\
 set_attribute module \$top    ip            \[list \\' $2
 
-if [ $DDRI_USED == "TRUE" ]; then
-  sed -i '/top    synth_options/ a\
+sed -i '/top    synth_options/ a\
 set_attribute module $top    synthXDC      \[list \\\
                                              \$rootDir/setup/donut_synth.xdc \\\
                                            \]' $2
-fi
 
 sed -i '/linkXDC/ d' $2
 
@@ -77,13 +75,13 @@ if [ $ILA_DEBUG == "TRUE" ]; then
                                              \$rootDir/setup/debug.xdc \\' $2
 fi
 
-if [ $DDR3_USED == "TRUE" ] && [ $BRAM_USED != "TRUE"  ] ; then
+if [ $DDR3_USED == "TRUE" ]; then
   sed -i '/top      top/ a\
-                                              \$dimmDir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_locs_b1_8g_x72ecc.xdc \\\
-                                              \$dimmDir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_dm_b1_x72ecc.xdc \\' $2
+                                             \$dimmDir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_locs_b1_8g_x72ecc.xdc \\\
+                                             \$dimmDir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/ddr3sdram_dm_b1_x72ecc.xdc \\' $2
 fi
 
-if [ $DDR4_USED == "TRUE" ] && [ $BRAM_USED != "TRUE"  ]; then
+if [ $DDR4_USED == "TRUE" ]; then
   sed -i '/top      top/ a\
                                              \$dimmDir/snap_ddr4pins_flash_gt.xdc \\' $2
 fi
@@ -91,31 +89,19 @@ fi
 if [ $FPGACARD == "KU3" ]; then 
   sed -i '/top      top/ a\
                                              \$rootDir/setup/donut_pblock.xdc \\' $2
-fi
 
-if [ $BRAM_USED == "TRUE" ]; then
-  if [ $FPGACARD == "KU3" ]; then 
+  if [ $BRAM_USED == "TRUE" ] || [ $DDR3_USED == "TRUE" ]; then
     sed -i '/top      top/ a\
-                                             \$dimmDir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/refclk200.xdc \\' $2
-  else 
+                                             \$dimmDir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/refclk200.xdc \\\
+                                             \$rootDir/setup/donut_link.xdc \\' $2
+  fi
+else 
+  if [ $BRAM_USED == "TRUE" ] || [ $DDR4_USED == "TRUE" ]; then
     sed -i '/top      top/ a\
-                                             \$dimmDir/snap_refclk266.xdc \\' $2
+                                             \$dimmDir/snap_refclk266.xdc \\\
+                                             \$rootDir/setup/donut_link.xdc \\' $2
   fi
 fi
-
-if [ $DDR3_USED == "TRUE" ]; then
-  sed -i '/top      top/ a\
-                                             \$dimmDir/example/dimm_test-admpcieku3-v3_0_0/fpga/src/refclk200.xdc \\' $2
-fi
-
-if [ $DDR4_USED == "TRUE" ]; then
-  sed -i '/top      top/ a\
-                                             \$dimmDir/snap_refclk266.xdc \\' $2
-fi
-
-sed -i '/top      top/ a\
-                                             \$rootDir/setup/donut_link.xdc \\' $2
-
 
 sed -i '/top      top/ a\
 set_attribute impl \$top      linkXDC       \[list \\' $2

--- a/hardware/setup/patch_vhd.sh
+++ b/hardware/setup/patch_vhd.sh
@@ -33,7 +33,7 @@ fi
 
 NAME=`basename $2`
 
-if ([ "$NAME" == "psl_accel_sim.vhd" ] || [ "$NAME" == "psl_accel_syn.vhd" ]); then
+if ([ "$NAME" == "psl_accel.vhd" ]); then
   sed -i 's/C_AXI_CARD_MEM0_ID_WIDTH[ ^I]*:[ ^I]*integer[ ^I]*:=[ ^I]*[0-9]*/C_AXI_CARD_MEM0_ID_WIDTH       : integer   := '$NUM_OF_ACTIONS'/' $1/$2
   sed -i 's/C_AXI_HOST_MEM_ID_WIDTH[ ^I]*:[ ^I]*integer[ ^I]*:=[ ^I]*[0-9]*/C_AXI_HOST_MEM_ID_WIDTH        : integer   := '$NUM_OF_ACTIONS'/' $1/$2
 fi


### PR DESCRIPTION
Signed-off-by: Thomas Fuchs <thomas.fuchs@de.ibm.com>

The order of the XDC files in psl_fpga.tcl was not correct. The refclk.xdc should be in front of donut_link.xdc.