### PR TITLE
HW: Removing HLS_WORKAROUND

### DIFF
--- a/hardware/hdl/core/psl_accel.vhd_source
+++ b/hardware/hdl/core/psl_accel.vhd_source
@@ -318,8 +318,8 @@ ARCHITECTURE psl_accel OF psl_accel IS
       ap_rst_n                   : IN STD_LOGIC;
       interrupt_ack              : in STD_LOGIC;
       interrupt                  : out std_logic;
-      interrupt_src              : out std_logic_vector(INT_BITS-2 DOWNTO 0);                           -- only for HLS_WORKAROUND!=TRUE
-      interrupt_ctx              : out std_logic_vector(CONTEXT_BITS-1 DOWNTO 0);                       -- only for HLS_WORKAROUND!=TRUE
+      interrupt_src              : out std_logic_vector(INT_BITS-2 DOWNTO 0);
+      interrupt_ctx              : out std_logic_vector(CONTEXT_BITS-1 DOWNTO 0);
       --                                                                                                -- only for DDRI_USED=TRUE
       -- AXI SDRAM Interface                                                                            -- only for DDRI_USED=TRUE
       m_axi_card_mem0_araddr     : OUT STD_LOGIC_VECTOR ( C_AXI_CARD_MEM0_ADDR_WIDTH-1 DOWNTO 0 );      -- only for DDRI_USED=TRUE
@@ -1469,8 +1469,8 @@ BEGIN
       ap_rst_n                             => action_reset_n_q,
       interrupt_ack                        => sk_d.int_req_ack,
       interrupt                            => ks_d.int_req,
-      interrupt_src                        => ks_d.int_src,                                 -- only for HLS_WORKAROUND!=TRUE
-      interrupt_ctx                        => ks_d.int_ctx,                                 -- only for HLS_WORKAROUND!=TRUE
+      interrupt_src                        => ks_d.int_src,
+      interrupt_ctx                        => ks_d.int_ctx,
       --                                                                                    -- only for DDRI_USED=TRUE
       -- AXI NVMe DDR Interface                                                             -- only for DDRI_USED=TRUE
       m_axi_card_mem0_araddr               => act_axi_card_mem0_araddr,                     -- only for DDRI_USED=TRUE

--- a/hardware/setup/snap_config.sh
+++ b/hardware/setup/snap_config.sh
@@ -55,17 +55,7 @@ else
   NVME_FILTER="\-\- only for NVME_USED=TRUE"
 fi
 
-if [ -z "$HLS_WORKAROUND" ] && [ `echo "$ACTION_ROOT" | sed 's/hls/xxx/' | sed 's/HLS/XXX/'` != "$ACTION_ROOT" ] ; then
-  HLS_WORKAROUND="TRUE"
-fi
-
-if [ "$HLS_WORKAROUND" == "TRUE" ]; then
-  HLS_WORKAROUND_FILTER="\-\- only for HLS_WORKAROUND!=TRUE"
-else
-  HLS_WORKAROUND_FILTER="\-\- only for HLS_WORKAROUND=TRUE"
-fi
-
-grep -v "$FPGA_FILTER" $1 | grep -v "$DDRI_FILTER" |  grep -v "$DDR3_FILTER" | grep -v "$DDR4_FILTER" | grep -v "$BRAM_FILTER" | grep -v "$NVME_FILTER" | grep -v "$HLS_WORKAROUND_FILTER" > $2
+grep -v "$FPGA_FILTER" $1 | grep -v "$DDRI_FILTER" |  grep -v "$DDR3_FILTER" | grep -v "$DDR4_FILTER" | grep -v "$BRAM_FILTER" | grep -v "$NVME_FILTER" > $2
 
 NAME=`basename $2`
 


### PR DESCRIPTION
Environment variable HLS_WORKAROUND accidentally got re-introduced with the merge of RC_NVMe_int.
Removing again.