### PR TITLE
HW: Adding dependency patch_version to Makefile_noHDK target config

### DIFF
--- a/hardware/Makefile_noHDK
+++ b/hardware/Makefile_noHDK
@@ -85,7 +85,7 @@ create_environment:
 	@cd $(DONUT_HARDWARE_ROOT)/setup                                    && vivado $(MSG_LEVEL) -mode batch -source create_framework.tcl -notrace -log $(LOGS_DIR)/vivado_create_framework_$(BUILD_DATE).log  -journal $(LOGS_DIR)/vivado_create_frame_work_$(BUILD_DATE).jou
 	@echo -e "\t[CREATE_ENVIRONMENT] done `date`"
 
-config: copy_denali $(BUILD_DIR)/Checkpoint/b_route_design.dcp $(SNAP_CONFIG_FILES) action_config create_environment patch_NVMe
+config: copy_denali $(BUILD_DIR)/Checkpoint/b_route_design.dcp $(SNAP_CONFIG_FILES) action_config create_environment patch_NVMe patch_version
 #config: copy_denali check_donut_settings $(BUILD_DIR)/Checkpoint/b_route_design.dcp $(SNAP_CONFIG_FILES) action_config create_environment
 
 	@echo -e "\t[CONFIG............] done `date`"


### PR DESCRIPTION
This allows synthesis within vivado gui after make config in no-HDK flow