### PR TITLE
HW: Making SDRAM and NVME configurable in HLS action_wrapper

### DIFF
--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -108,7 +108,9 @@ clean:
 	       hdl/core/snap_core_types.vhd			\
 	       hdl/core/psl_fpga.vhd				\
 	       hdl/core/psl_accel.vhd				\
-	       hdl/core/psl_accel_types.vhd
+	       hdl/core/psl_accel_types.vhd			\
+	       hdl/core/mmio.vhd				\
+	       hdl/hls/action_wrapper.vhd
 
 gitclean:
 	@echo -e "\t[GITCLEAN............] cleaning and resetting snap git";

--- a/hardware/Makefile_HDK
+++ b/hardware/Makefile_HDK
@@ -30,7 +30,8 @@ SNAP_CONFIG_FILES=$(SNAP_HDL_CORE)/psl_fpga.vhd \
 		  $(SNAP_SIM_CORE)/top.sv \
 		  $(SNAP_HDL_CORE)/snap_core.vhd \
 		  $(SNAP_HDL_CORE)/snap_core_types.vhd \
-		  $(SNAP_HDL_CORE)/mmio.vhd
+		  $(SNAP_HDL_CORE)/mmio.vhd \
+		  $(SNAP_HARDWARE_ROOT)/hdl/hls/action_wrapper.vhd
 
 PROJECT_COMPILE_LIST = $(SNAP_HARDWARE_ROOT)/sim/xsim/file_info.txt
 

--- a/hardware/Makefile_noHDK
+++ b/hardware/Makefile_noHDK
@@ -30,7 +30,8 @@ SNAP_CONFIG_FILES=$(SNAP_HDL_CORE)/psl_fpga.vhd \
 		  $(SNAP_SIM_CORE)/top.sv \
 		  $(SNAP_HDL_CORE)/snap_core.vhd \
 		  $(SNAP_HDL_CORE)/snap_core_types.vhd \
-		  $(SNAP_HDL_CORE)/mmio.vhd
+		  $(SNAP_HDL_CORE)/mmio.vhd \
+		  $(SNAP_HARDWARE_ROOT)/hdl/hls/action_wrapper.vhd
 
 
 .PHONY: all image model action_config create_environment copy config patch_version xpr_image snap_config snap_config_start

--- a/hardware/hdl/hls/action_wrapper.vhd_source
+++ b/hardware/hdl/hls/action_wrapper.vhd_source
@@ -24,7 +24,6 @@ USE ieee.std_logic_unsigned.all;
 USE ieee.numeric_std.all;
 
 
-
 ENTITY action_wrapper IS
   GENERIC (
     -- Parameters for Axi Master Bus Interface AXI_CARD_MEM0 : to DDR memory
@@ -107,6 +106,52 @@ ENTITY action_wrapper IS
     m_axi_card_mem0_wstrb      : OUT STD_LOGIC_VECTOR ( (C_M_AXI_CARD_MEM0_DATA_WIDTH/8)-1 DOWNTO 0 ); -- only for DDRI_USED=TRUE
     m_axi_card_mem0_wuser      : OUT STD_LOGIC_VECTOR ( C_M_AXI_CARD_MEM0_WUSER_WIDTH-1 DOWNTO 0 );    -- only for DDRI_USED=TRUE
     m_axi_card_mem0_wvalid     : OUT STD_LOGIC;                                                        -- only for DDRI_USED=TRUE
+    --                                                                                                 -- only for NVME_USED=TRUE
+    -- AXI NVME Interface                                                                              -- only for NVME_USED=TRUE
+    m_axi_nvme_araddr          : OUT STD_LOGIC_VECTOR ( 31 DOWNTO 0 );                                 -- only for NVME_USED=TRUE
+    m_axi_nvme_arburst         : OUT STD_LOGIC_VECTOR ( 1 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_arcache         : OUT STD_LOGIC_VECTOR ( 3 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_arid            : OUT STD_LOGIC_VECTOR ( 0 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_arlen           : OUT STD_LOGIC_VECTOR ( 7 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_arlock          : OUT STD_LOGIC;                                                        -- only for NVME_USED=TRUE
+    m_axi_nvme_arprot          : OUT STD_LOGIC_VECTOR ( 2 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_arqos           : OUT STD_LOGIC_VECTOR ( 3 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_arready         : IN  STD_LOGIC;                                                        -- only for NVME_USED=TRUE
+    m_axi_nvme_arregion        : OUT STD_LOGIC_VECTOR ( 3 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_arsize          : OUT STD_LOGIC_VECTOR ( 2 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_aruser          : OUT STD_LOGIC_VECTOR ( 0 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_arvalid         : OUT STD_LOGIC;                                                        -- only for NVME_USED=TRUE
+    m_axi_nvme_awaddr          : OUT STD_LOGIC_VECTOR ( 31 DOWNTO 0 );                                 -- only for NVME_USED=TRUE
+    m_axi_nvme_awburst         : OUT STD_LOGIC_VECTOR ( 1 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_awcache         : OUT STD_LOGIC_VECTOR ( 3 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_awid            : OUT STD_LOGIC_VECTOR ( 0 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_awlen           : OUT STD_LOGIC_VECTOR ( 7 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_awlock          : OUT STD_LOGIC;                                                        -- only for NVME_USED=TRUE
+    m_axi_nvme_awprot          : OUT STD_LOGIC_VECTOR ( 2 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_awqos           : OUT STD_LOGIC_VECTOR ( 3 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_awready         : IN  STD_LOGIC;                                                        -- only for NVME_USED=TRUE
+    m_axi_nvme_awregion        : OUT STD_LOGIC_VECTOR ( 3 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_awsize          : OUT STD_LOGIC_VECTOR ( 2 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_awuser          : OUT STD_LOGIC_VECTOR ( 0 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_awvalid         : OUT STD_LOGIC;                                                        -- only for NVME_USED=TRUE
+    m_axi_nvme_bid             : IN  STD_LOGIC_VECTOR ( 0 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_bready          : OUT STD_LOGIC;                                                        -- only for NVME_USED=TRUE
+    m_axi_nvme_bresp           : IN  STD_LOGIC_VECTOR ( 1 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_buser           : IN  STD_LOGIC_VECTOR ( 0 downto 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_bvalid          : IN  STD_LOGIC;                                                        -- only for NVME_USED=TRUE
+    m_axi_nvme_rdata           : IN  STD_LOGIC_VECTOR ( 31 DOWNTO 0 );                                 -- only for NVME_USED=TRUE
+    m_axi_nvme_rid             : IN  STD_LOGIC_VECTOR (  0 DOWNTO 0 );                                 -- only for NVME_USED=TRUE
+    m_axi_nvme_rlast           : IN  STD_LOGIC;                                                        -- only for NVME_USED=TRUE
+    m_axi_nvme_rready          : OUT STD_LOGIC;                                                        -- only for NVME_USED=TRUE
+    m_axi_nvme_rresp           : IN  STD_LOGIC_VECTOR ( 1 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_ruser           : IN  STD_LOGIC_VECTOR ( 0 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_rvalid          : IN  STD_LOGIC;                                                        -- only for NVME_USED=TRUE
+    m_axi_nvme_wdata           : OUT STD_LOGIC_VECTOR (31 DOWNTO 0 );                                  -- only for NVME_USED=TRUE
+    m_axi_nvme_wlast           : OUT STD_LOGIC;                                                        -- only for NVME_USED=TRUE
+    m_axi_nvme_wready          : IN  STD_LOGIC;                                                        -- only for NVME_USED=TRUE
+    m_axi_nvme_wstrb           : OUT STD_LOGIC_VECTOR (3 DOWNTO 0 );                                   -- only for NVME_USED=TRUE
+    m_axi_nvme_wuser           : OUT STD_LOGIC_VECTOR (0 DOWNTO 0 );                                   -- only for NVME_USED=TRUE
+    m_axi_nvme_wvalid          : OUT STD_LOGIC;                                                        -- only for NVME_USED=TRUE
     --
     -- AXI Control Register Interface
     s_axi_ctrl_reg_araddr      : IN  STD_LOGIC_VECTOR ( C_S_AXI_CTRL_REG_ADDR_WIDTH-1 DOWNTO 0 );
@@ -260,8 +305,55 @@ ARCHITECTURE STRUCTURE OF action_wrapper IS
       m_axi_card_mem0_buser      : IN  STD_LOGIC_VECTOR(C_M_AXI_CARD_MEM0_BUSER_WIDTH-1 DOWNTO 0);   -- only for DDRI_USED=TRUE
       m_axi_card_mem0_rid        : IN  STD_LOGIC_VECTOR(C_M_AXI_CARD_MEM0_ID_WIDTH-1 DOWNTO 0);      -- only for DDRI_USED=TRUE
       m_axi_card_mem0_ruser      : IN  STD_LOGIC_VECTOR(C_M_AXI_CARD_MEM0_RUSER_WIDTH-1 DOWNTO 0);   -- only for DDRI_USED=TRUE
-      m_axi_card_mem0_wid        : OUT STD_LOGIC_VECTOR (C_M_AXI_CARD_MEM0_ID_WIDTH-1 DOWNTO 0);      -- only for DDRI_USED=TRUE
+      m_axi_card_mem0_wid        : OUT STD_LOGIC_VECTOR (C_M_AXI_CARD_MEM0_ID_WIDTH-1 DOWNTO 0);     -- only for DDRI_USED=TRUE
       m_axi_card_mem0_wuser      : OUT STD_LOGIC_VECTOR(C_M_AXI_CARD_MEM0_WUSER_WIDTH-1 DOWNTO 0);   -- only for DDRI_USED=TRUE
+      --                                                                                             -- only for NVME_USED=TRUE
+      -- Ports of Axi Master Bus Interface AXI_NVME                                                  -- only for NVME_USED=TRUE
+      --       to DDR memory                                                                         -- only for NVME_USED=TRUE
+      axi_nvme_awaddr            : OUT STD_LOGIC_VECTOR(31 DOWNTO 0);                                -- only for NVME_USED=TRUE
+      axi_nvme_awlen             : OUT STD_LOGIC_VECTOR(7 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_awsize            : OUT STD_LOGIC_VECTOR(2 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_awburst           : OUT STD_LOGIC_VECTOR(1 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_awlock            : OUT STD_LOGIC;                                                    -- only for NVME_USED=TRUE
+      axi_nvme_awcache           : OUT STD_LOGIC_VECTOR(3 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_awprot            : OUT STD_LOGIC_VECTOR(2 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_awregion          : OUT STD_LOGIC_VECTOR(3 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_awqos             : OUT STD_LOGIC_VECTOR(3 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_awvalid           : OUT STD_LOGIC;                                                    -- only for NVME_USED=TRUE
+      axi_nvme_awready           : IN  STD_LOGIC;                                                    -- only for NVME_USED=TRUE
+      axi_nvme_wdata             : OUT STD_LOGIC_VECTOR(31 downto 0);                                -- only for NVME_USED=TRUE
+      axi_nvme_wstrb             : OUT STD_LOGIC_VECTOR(3 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_wlast             : OUT STD_LOGIC;                                                    -- only for NVME_USED=TRUE
+      axi_nvme_wvalid            : OUT STD_LOGIC;                                                    -- only for NVME_USED=TRUE
+      axi_nvme_wready            : IN  STD_LOGIC;                                                    -- only for NVME_USED=TRUE
+      axi_nvme_bresp             : IN  STD_LOGIC_VECTOR(1 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_bvalid            : IN  STD_LOGIC;                                                    -- only for NVME_USED=TRUE
+      axi_nvme_bready            : OUT STD_LOGIC;                                                    -- only for NVME_USED=TRUE
+      axi_nvme_araddr            : OUT STD_LOGIC_VECTOR(31 downto 0);                                -- only for NVME_USED=TRUE
+      axi_nvme_arlen             : OUT STD_LOGIC_VECTOR(7 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_arsize            : OUT STD_LOGIC_VECTOR(2 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_arburst           : OUT STD_LOGIC_VECTOR(1 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_arlock            : OUT STD_LOGIC;                                                    -- only for NVME_USED=TRUE
+      axi_nvme_arcache           : OUT STD_LOGIC_VECTOR(3 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_arprot            : OUT STD_LOGIC_VECTOR(2 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_arregion          : OUT STD_LOGIC_VECTOR(3 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_arqos             : OUT STD_LOGIC_VECTOR(3 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_arvalid           : OUT STD_LOGIC;                                                    -- only for NVME_USED=TRUE
+      axi_nvme_arready           : IN  STD_LOGIC;                                                    -- only for NVME_USED=TRUE
+      axi_nvme_rdata             : IN  STD_LOGIC_VECTOR(31 DOWNTO 0);                                -- only for NVME_USED=TRUE
+      axi_nvme_rresp             : IN  STD_LOGIC_VECTOR(1 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_rlast             : IN  STD_LOGIC;                                                    -- only for NVME_USED=TRUE
+      axi_nvme_rvalid            : IN  STD_LOGIC;                                                    -- only for NVME_USED=TRUE
+      axi_nvme_rready            : OUT STD_LOGIC;                                                    -- only for NVME_USED=TRUE
+      axi_nvme_arid              : OUT STD_LOGIC_VECTOR(0 downto 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_aruser            : OUT STD_LOGIC_VECTOR(0 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_awid              : OUT STD_LOGIC_VECTOR(0 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_awuser            : OUT STD_LOGIC_VECTOR(0 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_bid               : IN  STD_LOGIC_VECTOR(0 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_buser             : IN  STD_LOGIC_VECTOR(0 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_rid               : IN  STD_LOGIC_VECTOR(0 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_ruser             : IN  STD_LOGIC_VECTOR(0 DOWNTO 0);                                 -- only for NVME_USED=TRUE
+      axi_nvme_wuser             : OUT STD_LOGIC_VECTOR(0 DOWNTO 0);                                 -- only for NVME_USED=TRUE
       --
       -- Ports of Axi Slave Bus Interface AXI_CTRL_REG
       s_axi_ctrl_reg_awaddr      : IN  STD_LOGIC_VECTOR(C_S_AXI_CTRL_REG_ADDR_WIDTH-1 DOWNTO 0);
@@ -367,7 +459,7 @@ BEGIN
     m_axi_card_mem0_araddr       => m_axi_card_mem0_araddr,                                -- only for DDRI_USED=TRUE
     m_axi_card_mem0_arburst      => m_axi_card_mem0_arburst,                               -- only for DDRI_USED=TRUE
     m_axi_card_mem0_arcache      => m_axi_card_mem0_arcache,                               -- only for DDRI_USED=TRUE
-    m_axi_card_mem0_arid         => m_axi_card_mem0_arid( 0 DOWNTO 0),--SR# 10394170                                  -- only for DDRI_USED=TRUE
+    m_axi_card_mem0_arid         => m_axi_card_mem0_arid( 0 DOWNTO 0),--SR# 10394170       -- only for DDRI_USED=TRUE
     m_axi_card_mem0_arlen        => m_axi_card_mem0_arlen,                                 -- only for DDRI_USED=TRUE
     m_axi_card_mem0_arlock       => m_axi_card_mem0_arlock,                                -- only for DDRI_USED=TRUE
     m_axi_card_mem0_arprot       => m_axi_card_mem0_arprot,                                -- only for DDRI_USED=TRUE
@@ -380,7 +472,7 @@ BEGIN
     m_axi_card_mem0_awaddr       => m_axi_card_mem0_awaddr,                                -- only for DDRI_USED=TRUE
     m_axi_card_mem0_awburst      => m_axi_card_mem0_awburst,                               -- only for DDRI_USED=TRUE
     m_axi_card_mem0_awcache      => m_axi_card_mem0_awcache,                               -- only for DDRI_USED=TRUE
-    m_axi_card_mem0_awid         => m_axi_card_mem0_awid(0 DOWNTO 0),--SR# 10394170                                  -- only for DDRI_USED=TRUE
+    m_axi_card_mem0_awid         => m_axi_card_mem0_awid(0 DOWNTO 0),--SR# 10394170        -- only for DDRI_USED=TRUE
     m_axi_card_mem0_awlen        => m_axi_card_mem0_awlen,                                 -- only for DDRI_USED=TRUE
     m_axi_card_mem0_awlock       => m_axi_card_mem0_awlock,                                -- only for DDRI_USED=TRUE
     m_axi_card_mem0_awprot       => m_axi_card_mem0_awprot,                                -- only for DDRI_USED=TRUE
@@ -390,13 +482,13 @@ BEGIN
     m_axi_card_mem0_awsize       => m_axi_card_mem0_awsize,                                -- only for DDRI_USED=TRUE
     m_axi_card_mem0_awuser       => m_axi_card_mem0_awuser,                                -- only for DDRI_USED=TRUE
     m_axi_card_mem0_awvalid      => m_axi_card_mem0_awvalid,                               -- only for DDRI_USED=TRUE
-    m_axi_card_mem0_bid          => m_axi_card_mem0_bid(0 DOWNTO 0),--SR# 10394170                                   -- only for DDRI_USED=TRUE
+    m_axi_card_mem0_bid          => m_axi_card_mem0_bid(0 DOWNTO 0),--SR# 10394170         -- only for DDRI_USED=TRUE
     m_axi_card_mem0_bready       => m_axi_card_mem0_bready,                                -- only for DDRI_USED=TRUE
     m_axi_card_mem0_bresp        => m_axi_card_mem0_bresp,                                 -- only for DDRI_USED=TRUE
     m_axi_card_mem0_buser        => m_axi_card_mem0_buser,                                 -- only for DDRI_USED=TRUE
     m_axi_card_mem0_bvalid       => m_axi_card_mem0_bvalid,                                -- only for DDRI_USED=TRUE
     m_axi_card_mem0_rdata        => m_axi_card_mem0_rdata,                                 -- only for DDRI_USED=TRUE
-    m_axi_card_mem0_rid          => m_axi_card_mem0_rid(0 DOWNTO 0),--SR# 10394170                                   -- only for DDRI_USED=TRUE
+    m_axi_card_mem0_rid          => m_axi_card_mem0_rid(0 DOWNTO 0),--SR# 10394170         -- only for DDRI_USED=TRUE
     m_axi_card_mem0_rlast        => m_axi_card_mem0_rlast,                                 -- only for DDRI_USED=TRUE
     m_axi_card_mem0_rready       => m_axi_card_mem0_rready,                                -- only for DDRI_USED=TRUE
     m_axi_card_mem0_rresp        => m_axi_card_mem0_rresp,                                 -- only for DDRI_USED=TRUE
@@ -409,6 +501,50 @@ BEGIN
     m_axi_card_mem0_wstrb        => m_axi_card_mem0_wstrb,                                 -- only for DDRI_USED=TRUE
     m_axi_card_mem0_wuser        => m_axi_card_mem0_wuser,                                 -- only for DDRI_USED=TRUE
     m_axi_card_mem0_wvalid       => m_axi_card_mem0_wvalid,                                -- only for DDRI_USED=TRUE
+    axi_nvme_araddr              => m_axi_nvme_araddr,                                     -- only for NVME_USED=TRUE
+    axi_nvme_arburst             => m_axi_nvme_arburst,                                    -- only for NVME_USED=TRUE
+    axi_nvme_arcache             => m_axi_nvme_arcache,                                    -- only for NVME_USED=TRUE
+    axi_nvme_arid                => m_axi_nvme_arid,                                       -- only for NVME_USED=TRUE
+    axi_nvme_arlen               => m_axi_nvme_arlen,                                      -- only for NVME_USED=TRUE
+    axi_nvme_arlock              => m_axi_nvme_arlock,                                     -- only for NVME_USED=TRUE
+    axi_nvme_arprot              => m_axi_nvme_arprot,                                     -- only for NVME_USED=TRUE
+    axi_nvme_arqos               => m_axi_nvme_arqos,                                      -- only for NVME_USED=TRUE
+    axi_nvme_arready             => m_axi_nvme_arready,                                    -- only for NVME_USED=TRUE
+    axi_nvme_arregion            => m_axi_nvme_arregion,                                   -- only for NVME_USED=TRUE
+    axi_nvme_arsize              => m_axi_nvme_arsize,                                     -- only for NVME_USED=TRUE
+    axi_nvme_aruser              => m_axi_nvme_aruser,                                     -- only for NVME_USED=TRUE
+    axi_nvme_arvalid             => m_axi_nvme_arvalid,                                    -- only for NVME_USED=TRUE
+    axi_nvme_awaddr              => m_axi_nvme_awaddr,                                     -- only for NVME_USED=TRUE
+    axi_nvme_awburst             => m_axi_nvme_awburst,                                    -- only for NVME_USED=TRUE
+    axi_nvme_awcache             => m_axi_nvme_awcache,                                    -- only for NVME_USED=TRUE
+    axi_nvme_awid                => m_axi_nvme_awid,                                       -- only for NVME_USED=TRUE
+    axi_nvme_awlen               => m_axi_nvme_awlen,                                      -- only for NVME_USED=TRUE
+    axi_nvme_awlock              => m_axi_nvme_awlock,                                     -- only for NVME_USED=TRUE
+    axi_nvme_awprot              => m_axi_nvme_awprot,                                     -- only for NVME_USED=TRUE
+    axi_nvme_awqos               => m_axi_nvme_awqos,                                      -- only for NVME_USED=TRUE
+    axi_nvme_awready             => m_axi_nvme_awready,                                    -- only for NVME_USED=TRUE
+    axi_nvme_awregion            => m_axi_nvme_awregion,                                   -- only for NVME_USED=TRUE
+    axi_nvme_awsize              => m_axi_nvme_awsize,                                     -- only for NVME_USED=TRUE
+    axi_nvme_awuser              => m_axi_nvme_awuser,                                     -- only for NVME_USED=TRUE
+    axi_nvme_awvalid             => m_axi_nvme_awvalid,                                    -- only for NVME_USED=TRUE
+    axi_nvme_bid                 => m_axi_nvme_bid,                                        -- only for NVME_USED=TRUE
+    axi_nvme_bready              => m_axi_nvme_bready,                                     -- only for NVME_USED=TRUE
+    axi_nvme_bresp               => m_axi_nvme_bresp,                                      -- only for NVME_USED=TRUE
+    axi_nvme_buser               => m_axi_nvme_buser,                                      -- only for NVME_USED=TRUE
+    axi_nvme_bvalid              => m_axi_nvme_bvalid,                                     -- only for NVME_USED=TRUE
+    axi_nvme_rdata               => m_axi_nvme_rdata,                                      -- only for NVME_USED=TRUE
+    axi_nvme_rid                 => m_axi_nvme_rid,                                        -- only for NVME_USED=TRUE
+    axi_nvme_rlast               => m_axi_nvme_rlast,                                      -- only for NVME_USED=TRUE
+    axi_nvme_rready              => m_axi_nvme_rready,                                     -- only for NVME_USED=TRUE
+    axi_nvme_rresp               => m_axi_nvme_rresp,                                      -- only for NVME_USED=TRUE
+    axi_nvme_ruser               => m_axi_nvme_ruser,                                      -- only for NVME_USED=TRUE
+    axi_nvme_rvalid              => m_axi_nvme_rvalid,                                     -- only for NVME_USED=TRUE
+    axi_nvme_wdata               => m_axi_nvme_wdata,                                      -- only for NVME_USED=TRUE
+    axi_nvme_wlast               => m_axi_nvme_wlast,                                      -- only for NVME_USED=TRUE
+    axi_nvme_wready              => m_axi_nvme_wready,                                     -- only for NVME_USED=TRUE
+    axi_nvme_wstrb               => m_axi_nvme_wstrb,                                      -- only for NVME_USED=TRUE
+    axi_nvme_wuser               => m_axi_nvme_wuser,                                      -- only for NVME_USED=TRUE
+    axi_nvme_wvalid              => m_axi_nvme_wvalid,                                     -- only for NVME_USED=TRUE
     s_axi_ctrl_reg_araddr        => s_axi_ctrl_reg_araddr,
     s_axi_ctrl_reg_arready       => s_axi_ctrl_reg_arready,
     s_axi_ctrl_reg_arvalid       => s_axi_ctrl_reg_arvalid,


### PR DESCRIPTION
This is meant as fix for #264.

@luyong6 could you please try it to see if it works with your HLS example not using SDRAM (I do not have such an example - so, I can't test it myself).
Thanks