### PR TITLE
HW: Control ah_paren via SNAP Debug register

### DIFF
--- a/hardware/doc/SNAP-Registers.md
+++ b/hardware/doc/SNAP-Registers.md
@@ -269,6 +269,29 @@ Address: 0x00C000 + m * 0x0000008 (m = 0,..,15)
 
 ---
 
+#### SNAP Debug Register (SDR)
+```
+Address: 0x000D000
+  63..1  RO: Reserved
+      0  RW: Disable parity checking on ah Interface by PSL
+                 '1': Parity checking is disabled (default value, until all parity problems are fixed)
+                 '0': Parity checking is enabled
+
+  POR value: 0x00000000_00000001
+```
+
+---
+
+#### SNAP NVMe Register (SNR)
+```
+Address: 0x000D008
+  63..0  RW: Reserved for NVMe usage
+
+  POR value: 0x00000000_00000000
+```
+
+---
+
 #### Job-Manager FIRs
 ##### Not yet implemented
 ```
@@ -700,6 +723,29 @@ Address: 0x0001080 + (s+n) * 0x0010000
 Address: 0x00C000 + (s+n) * 0x0010000 + m * 0x0000008 (m = 0,..,15)
   63..32 RO: Reserved
   31..0  RO: Context m*32+k is attached if (and only if) bit k is set (for each k = 0,..,31).
+```
+
+---
+
+#### SNAP Debug Register (SDR)
+```
+Address: 0x000D000 + (s+n) * 0x0010000
+  63..1  RO: Reserved
+      0  RO: Disable parity checking on ah Interface by PSL
+                 '1': Parity checking is disabled (default value, until all parity problems are fixed)
+                 '0': Parity checking is enabled
+
+  POR value: 0x00000000_00000001
+```
+
+---
+
+#### SNAP NVMe Register (SNR)
+```
+Address: 0x000D008 + (s+n) * 0x0010000
+  63..0  RO: Reserved for NVMe usage
+
+  POR value: 0x00000000_00000000
 ```
 
 ---

--- a/hardware/hdl/core/mmio.vhd_source
+++ b/hardware/hdl/core/mmio.vhd_source
@@ -40,8 +40,6 @@ ENTITY mmio IS
     ha_pclock              : IN  std_logic;
     afu_reset              : IN  std_logic;
     nvme_reset_ctl         : OUT std_logic_vector(SNAP_NVME_RST_L  DOWNTO SNAP_NVME_RST_R);   -- only for NVME_USED=TRUE  -- keeping NVMe drives in reset by driving 0's
-    --
-    -- debug (TODO: remove)
     ah_paren_mm_o          : OUT std_logic;
     --
     -- PSL IOs
@@ -703,10 +701,8 @@ BEGIN
 
         dbg_regs_q                       <= (OTHERS => (OTHERS => '0'));
         dbg_regs_par_q                   <= (OTHERS => '1');
-        dbg_regs_q(14)                   <= IMP_VERSION_DAT;
-        dbg_regs_par_q(14)               <= parity_gen_odd(IMP_VERSION_DAT);
-        dbg_regs_q(15)                   <= BUILD_DATE_DAT;
-        dbg_regs_par_q(15)               <= parity_gen_odd(BUILD_DATE_DAT);
+        dbg_regs_q(SNAP_DEBUG_REG)(SNAP_DBG_AH_PAREN) <= '1';  -- TODO: Change reset value, when all parity problems are resolved
+        dbg_regs_par_q(SNAP_DEBUG_REG)                <= '0';
 
         exploration_done_q               <= '0';
 
@@ -1133,6 +1129,12 @@ BEGIN
     ah_mm_o.data    <= ah_mm_q.data;
     ah_mm_o.datapar <= ah_mm_q.datapar; -- XOR mm_i_q.inject_read_rsp_parity_error;  -- toggle parity iff inject_read_rsp_parity_error is set to '1';
 
+    --
+    -- Parity enable for ah interface in PSL
+    --
+    ah_paren_mm_o   <= NOT dbg_regs_q(SNAP_DEBUG_REG)(SNAP_DBG_AH_PAREN);
+
+    --
     -- MMC
     --
     mmc_c_o.reset_done <= NOT regs_reset_q;

--- a/hardware/hdl/core/snap_core_types.vhd_source
+++ b/hardware/hdl/core/snap_core_types.vhd_source
@@ -222,6 +222,9 @@ PACKAGE snap_core_types IS
   CONSTANT SNAP_FRT_REG               : integer := 16#0#;
   CONSTANT SNAP_LOCK_REG              : integer := 16#4#;
   CONSTANT SNAP_CTX_ID_REG            : integer := 16#4#;
+  -- SNAP debug REGISTER
+  CONSTANT SNAP_DEBUG_REG             : integer := 16#0#;
+  CONSTANT SNAP_NVME_REG              : integer := 16#1#;
 
   -- ACTION_TYPE and ACTION_COUNTER registers
   CONSTANT MAX_ACTION_REG             : integer := 16#F#;
@@ -252,6 +255,7 @@ PACKAGE snap_core_types IS
   CONSTANT SNAP_CTX_ID_R              : integer :=  0;     -- SNAP_CTX_ID_REG
   CONSTANT SNAP_NVME_RST_L            : integer :=  4;     -- SNAP_RESET_REG
   CONSTANT SNAP_NVME_RST_R            : integer :=  0;     -- SNAP_RESET_REG
+  CONSTANT SNAP_DBG_AH_PAREN          : integer :=  0;     -- SNAP_DEBUG_REG
 
   CONSTANT CTX_CFG_SIZE_INT           : integer := 39;     -- CONTEXT_CONFIG_REG
   CONSTANT CTX_CFG_FIRST_SEQNO_L      : integer := 63;     -- CONTEXT_CONFIG_REG
@@ -731,7 +735,7 @@ PACKAGE snap_core_types IS
   ----------------------------------------------------------------------------
   ----------------------------------------------------------------------------
     --
-    -- ds_c 
+    -- ds_c
     --
     TYPE DS_C_T IS RECORD
       wr_req_ack        : std_logic;
@@ -1070,7 +1074,7 @@ PACKAGE BODY snap_core_types IS
       VARIABLE res : std_logic;
     BEGIN
       res := data(data'low);
-      
+
       FOR i IN data'low+1 TO data'high LOOP
         res := data(i) XOR res;
       END LOOP;  -- i
@@ -1084,7 +1088,7 @@ PACKAGE BODY snap_core_types IS
       VARIABLE res : std_logic;
     BEGIN
       res := data(data'low);
-      
+
       FOR i  IN data'low+1 TO data'high LOOP
         res := data(i) XOR res;
       END LOOP;  -- i


### PR DESCRIPTION
Driving the output ah_paren to PSL from MMIO register 0xD000 bit 0.
Per default ah_paren is driven to 0.
See also updated documentation in SNAP-Registers.md

This is meant as fix for #262