### PR TITLE
Another fix for issue #264

### DIFF
--- a/hardware/hdl/hls/action_wrapper.vhd_source
+++ b/hardware/hdl/hls/action_wrapper.vhd_source
@@ -231,15 +231,15 @@ ARCHITECTURE STRUCTURE OF action_wrapper IS
 
   COMPONENT hls_action
     GENERIC (
-      -- Parameters for Axi Master Bus Interface AXI_CARD_MEM0 : to DDR memory
-      C_M_AXI_CARD_MEM0_ID_WIDTH       : integer;
-      C_M_AXI_CARD_MEM0_ADDR_WIDTH     : integer;
-      C_M_AXI_CARD_MEM0_DATA_WIDTH     : integer;
-      C_M_AXI_CARD_MEM0_AWUSER_WIDTH   : integer;
-      C_M_AXI_CARD_MEM0_ARUSER_WIDTH   : integer;
-      C_M_AXI_CARD_MEM0_WUSER_WIDTH    : integer;
-      C_M_AXI_CARD_MEM0_RUSER_WIDTH    : integer;
-      C_M_AXI_CARD_MEM0_BUSER_WIDTH    : integer;
+      -- Parameters for Axi Master Bus Interface AXI_CARD_MEM0 : to DDR memory                       -- only for DDRI_USED=TRUE
+      C_M_AXI_CARD_MEM0_ID_WIDTH       : integer;                                                    -- only for DDRI_USED=TRUE
+      C_M_AXI_CARD_MEM0_ADDR_WIDTH     : integer;                                                    -- only for DDRI_USED=TRUE
+      C_M_AXI_CARD_MEM0_DATA_WIDTH     : integer;                                                    -- only for DDRI_USED=TRUE
+      C_M_AXI_CARD_MEM0_AWUSER_WIDTH   : integer;                                                    -- only for DDRI_USED=TRUE
+      C_M_AXI_CARD_MEM0_ARUSER_WIDTH   : integer;                                                    -- only for DDRI_USED=TRUE
+      C_M_AXI_CARD_MEM0_WUSER_WIDTH    : integer;                                                    -- only for DDRI_USED=TRUE
+      C_M_AXI_CARD_MEM0_RUSER_WIDTH    : integer;                                                    -- only for DDRI_USED=TRUE
+      C_M_AXI_CARD_MEM0_BUSER_WIDTH    : integer;                                                    -- only for DDRI_USED=TRUE
 
       -- Parameters for Axi Slave Bus Interface AXI_CTRL_REG
       C_S_AXI_CTRL_REG_DATA_WIDTH      : integer;
@@ -429,15 +429,15 @@ BEGIN
 
   hls_action_0 : hls_action
   GENERIC MAP (
-    -- Parameters for Axi Master Bus Interface AXI_CARD_MEM0 : to DDR memory
-    C_M_AXI_CARD_MEM0_ID_WIDTH       => 1, --C_M_AXI_CARD_MEM0_ID_WIDTH, --SR# 10394170
-    C_M_AXI_CARD_MEM0_ADDR_WIDTH     => C_M_AXI_CARD_MEM0_ADDR_WIDTH,
-    C_M_AXI_CARD_MEM0_DATA_WIDTH     => C_M_AXI_CARD_MEM0_DATA_WIDTH,
-    C_M_AXI_CARD_MEM0_AWUSER_WIDTH   => C_M_AXI_CARD_MEM0_AWUSER_WIDTH,
-    C_M_AXI_CARD_MEM0_ARUSER_WIDTH   => C_M_AXI_CARD_MEM0_ARUSER_WIDTH,
-    C_M_AXI_CARD_MEM0_WUSER_WIDTH    => C_M_AXI_CARD_MEM0_WUSER_WIDTH,
-    C_M_AXI_CARD_MEM0_RUSER_WIDTH    => C_M_AXI_CARD_MEM0_RUSER_WIDTH,
-    C_M_AXI_CARD_MEM0_BUSER_WIDTH    => C_M_AXI_CARD_MEM0_BUSER_WIDTH,
+    -- Parameters for Axi Master Bus Interface AXI_CARD_MEM0 : to DDR memory               -- only for DDRI_USED=TRUE
+    C_M_AXI_CARD_MEM0_ID_WIDTH       => 1, --C_M_AXI_CARD_MEM0_ID_WIDTH, --SR# 10394170    -- only for DDRI_USED=TRUE
+    C_M_AXI_CARD_MEM0_ADDR_WIDTH     => C_M_AXI_CARD_MEM0_ADDR_WIDTH,                      -- only for DDRI_USED=TRUE
+    C_M_AXI_CARD_MEM0_DATA_WIDTH     => C_M_AXI_CARD_MEM0_DATA_WIDTH,                      -- only for DDRI_USED=TRUE
+    C_M_AXI_CARD_MEM0_AWUSER_WIDTH   => C_M_AXI_CARD_MEM0_AWUSER_WIDTH,                    -- only for DDRI_USED=TRUE
+    C_M_AXI_CARD_MEM0_ARUSER_WIDTH   => C_M_AXI_CARD_MEM0_ARUSER_WIDTH,                    -- only for DDRI_USED=TRUE
+    C_M_AXI_CARD_MEM0_WUSER_WIDTH    => C_M_AXI_CARD_MEM0_WUSER_WIDTH,                     -- only for DDRI_USED=TRUE
+    C_M_AXI_CARD_MEM0_RUSER_WIDTH    => C_M_AXI_CARD_MEM0_RUSER_WIDTH,                     -- only for DDRI_USED=TRUE
+    C_M_AXI_CARD_MEM0_BUSER_WIDTH    => C_M_AXI_CARD_MEM0_BUSER_WIDTH,                     -- only for DDRI_USED=TRUE
 
     -- Parameters for Axi Slave Bus Interface AXI_CTRL_REG
     C_S_AXI_CTRL_REG_DATA_WIDTH      => C_S_AXI_CTRL_REG_DATA_WIDTH,


### PR DESCRIPTION
Bruno made me aware of the fact that the fix for issue #264 was not complete.
Here is the fix for that (removing parameters for AXI_CARD_MEM0 in hls_action if no on-card SDRAM is used).

Please give it a try.
Thanks