### PR TITLE
Fix generation issue w/ Vivado HLS examples

### DIFF
--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -145,7 +145,7 @@ snap_config: snap_config_start $(SNAP_CONFIG_FILES)
 snap_config_start:
 	@echo -e "\t[CONFIG SNAP_CORE....] start";
 
-action_config: $(ACTION_ROOT)
+action_config: $(ACTION_ROOT)/vhdl
 	@echo -e "\t[CONFIG ACTION.......] start";
 	@if [ -e "$(ACTION_ROOT)/action_config.sh" ]; then \
 		cd $(ACTION_ROOT) && ./action_config.sh; \
@@ -154,7 +154,7 @@ action_config: $(ACTION_ROOT)
 # In case we have a HLS action there will be no vhdl directory,
 # such that ACTION_ROOT does not exist. To build it, we go one directory
 # above and issue "make", such that the vhdl code can be synthesized.
-$(ACTION_ROOT):
+$(ACTION_ROOT)/vhdl:
 	@echo -e "\t[CREATE_HLS_CODE.....] start `date`"
 	@echo -e "\t                        using `vivado_hls -v |grep Vivado`"
 	@make -C `dirname $(ACTION_ROOT)` > $(LOGS_DIR)/create_hls.log

--- a/hardware/setup/create_framework.tcl
+++ b/hardware/setup/create_framework.tcl
@@ -96,7 +96,11 @@ if { $hls_support == "TRUE" } {
 }
 set_property used_in_simulation false [get_files $hdl_dir/core/psl_fpga.vhd]
 # Action Files
-add_files            -fileset sources_1 -scan_for_includes $action_dir/
+if { $hls_support == "TRUE" } {
+  add_files            -fileset sources_1 -scan_for_includes $action_dir/vhdl/
+} else {
+  add_files            -fileset sources_1 -scan_for_includes $action_dir/
+}
 # Sim Files
 set_property SOURCE_SET sources_1 [get_filesets sim_1]
 add_files    -fileset sim_1 -norecurse -scan_for_includes $sim_dir/core/top.sv  >> $log_file


### PR DESCRIPTION
Fix 2 minor issues seen on my setup:

1) `make config` skips over creating the HLS source
`make $ACTION_ROOT` reports up to date w/o generating the RTL code w/ Vivado HLS


2) the generated Vivado project does not set psl_fpga as toplevel module and includes all the verilog and systemc from hls in addition to vhdl 

fix #317 


 