### PR TITLE
Check $ACTION_ROOT

### DIFF
--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -101,6 +101,11 @@ check_snap_settings:
 		echo "NUM_OF_ACTIONS: $(NUM_OF_ACTIONS)"; \
 		exit 1; \
 	fi
+	@if ([ -z `echo "x$(ACTION_ROOT)" | grep -iv HLS` ] || [ -z `echo "x$(HLS_SUPPORT)" | grep -iv TRUE` ]) && [ `basename "x$(ACTION_ROOT)"` != "vhdl" ] && [ `basename "x$(ACTION_ROOT)"` != "verilog" ]; then \
+		echo "Looks like an HLS action shall be integrated."; \
+		echo "Please make sure that the environment variable ACTION_ROOT ends in vhdl or in verilog"; \
+		exit 1; \
+	fi
 
 check_denali:
 	@if [ $(NVME_USED) == "TRUE" ]; then \

--- a/hardware/snap_settings
+++ b/hardware/snap_settings
@@ -99,6 +99,9 @@ while [ -z "$SETUP_DONE" ]; do
     echo "Setting ACTION_ROOT            to: \"$ACTION_ROOT\""
   else
     echo "ACTION_ROOT             is set to: \"$ACTION_ROOT\""
+    if [ -z `echo "x$ACTION_ROOT" | grep -iv HLS` ] && [ `basename "x$ACTION_ROOT"` != "vhdl" ] && [ `basename "x$ACTION_ROOT"` != "verilog" ]; then
+      SETUP_WARNING="$SETUP_WARNING\n### WARNING ### For HLS actions ACTION_ROOT needs to end in vhdl or in verilog"
+    fi
   fi
 
   echo "=====SNAP simulation variables========================="


### PR DESCRIPTION
Adding check for HLS actions that `$ACTION_ROOT` ends in `vhdl` or in `verilog`
This is a first approach to get a solution for issue #317