### PR TITLE
HLS search : removing offsets results displaying since not filled and…

### DIFF
--- a/software/examples/snap_search.c
+++ b/software/examples/snap_search.c
@@ -198,7 +198,7 @@ static int run_one_step(struct snap_action *action,
 }
 static void snap_print_search_results(struct snap_job *cjob, unsigned int run)
 {
-	unsigned int i;
+//	unsigned int i;
 	struct search_job *sjob = (struct search_job *)
 		(unsigned long)cjob->wout_addr;
 	uint64_t *offs;
@@ -225,12 +225,14 @@ static void snap_print_search_results(struct snap_job *cjob, unsigned int run)
 	if (verbose_flag > 2) {
 		offs = (uint64_t *)(unsigned long)sjob->ddr_result.addr;
 		offs_max = sjob->ddr_result.size / sizeof(uint64_t);
-		for (i = 0; i < MIN(sjob->nb_of_occurrences, offs_max); i++) {
-			printf("%3d: %016llx", i,
-			       (long long)__le64_to_cpu(offs[i]));
-			if (((i+1) % 3) == 0)
-				printf("\n");
-		}
+/* As long as action does not write position, no need to display meaningless values
+*		for (i = 0; i < MIN(sjob->nb_of_occurrences, offs_max); i++) {
+*			printf("%3d: %016llx", i,
+*			       (long long)__le64_to_cpu(offs[i]));
+*			if (((i+1) % 3) == 0)
+*				printf("\n");
+*		}
+*/
 		printf("\n");
 	}
 	if (verbose_flag > 1) {


### PR DESCRIPTION
HLS search : removing offsets results displaying since not filled and driving to a core dump

**Example run is:**
python -c 'print("X" * 1024)' > $SNAP_ROOT/1KiB_X.bin
ulimit -c unlimited
export DNUT_TRACE=0xf
./run_sim -explore -app examples/snap_search -arg "-vvv -t600 -E1024 -i $SNAP_ROOT/1KiB_X.bin -pX"

**Segmentation fault at line:**
               offs = (uint64_t *)(unsigned long)sjob->ddr_result.addr;
                offs_max = sjob->ddr_result.size / sizeof(uint64_t);
                for (i = 0; i < MIN(sjob->nb_of_occurrences, offs_max); i++) {
                        printf("%3d: %016llx", i,
                               (long long)__le64_to_cpu(offs[i]));
**values during run are:**
 Output: 0000000020000000 - 0000000020000150 CARD_DRAM                                                               
nb_of_occurrences :             1024 
offs_max 42                                                
so the index i will go from 0 to 41

As i'm not putting anything yet into the offs, i guess it's may be the reason...even if i don't understand why it could generate this core dump
Anyway, there is no reason to display the offs if they are not filled so i commented these lines....But this doesn't gives an explanation