### PR TITLE
HW project: Another fix for HLS actions

### DIFF
--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -283,6 +283,13 @@ clean:
 	@rm -r -f  sim/ies sim/xsim sim/questa hdl/nvme/component.xml hdl/nvme/xgui
 	@echo -e "\t                        log files";
 	@rm -r -f  logs
+	@if [ -e "$(ACTION_ROOT)/Makefile" ]; then          \
+		echo -e "\t                        action"; \
+		make -C $(ACTION_ROOT) $@ > /dev/null;      \
+		if [ $$? -ne 0 ]; then                      \
+			echo -e "\tError: [make "$@"] failed for action in $(ACTION_ROOT)";exit -1; \
+		fi                                          \
+	fi
 
 gitclean:
 	@echo -e "\t[GITCLEAN............] cleaning and resetting snap git";

--- a/hardware/setup/create_framework.tcl
+++ b/hardware/setup/create_framework.tcl
@@ -97,6 +97,7 @@ if { $hls_support == "TRUE" } {
   add_files -scan_for_includes $hdl_dir/hls/  >> $log_file
 }
 set_property used_in_simulation false [get_files $hdl_dir/core/psl_fpga.vhd]
+set_property top psl_fpga [current_fileset]
 # Action Files
 add_files            -fileset sources_1 -scan_for_includes $action_dir/
 # Sim Files


### PR DESCRIPTION
Another fix for issue #317
- Making sure that psl_fpga is top module for HLS actions
- Cleaning action with `make clean` from `snap/hardware` directory