### PR TITLE
Improved /bin/sh compatibility in hardware/Makefile

### DIFF
--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -105,7 +105,7 @@ check_snap_settings:
 		echo "Please make sure that the environment variable ACTION_ROOT points to a directory containing the action's source code."; \
 		exit 1; \
 	fi
-	@if [ `echo "$(ILA_DEBUG)" | tr a-z A-Z` == "TRUE" ] && [ ! -e "$(ILA_SETUP_FILE)" ]; then \
+	@if [ `echo "$(ILA_DEBUG)" | tr a-z A-Z` = "TRUE" ] && [ ! -e "$(ILA_SETUP_FILE)" ]; then \
 		echo "ILA_DEBUG is set to ${ILA_DEBUG} but ILA_SETUP_FILE is not pointing to a file!"; \
 		exit 1; \
 	fi

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -75,7 +75,7 @@ check_snap_settings:
 		echo "Please source snap_settings before calling make!"; \
 		exit 1; \
 	fi
-	@if [[ $(SIMULATOR) != "irun" && $(SIMULATOR) != "xsim" && $(SIMULATOR) != "questa" ]];then \
+	@if [ $(SIMULATOR) != "irun" ] && [ $(SIMULATOR) != "xsim" ] && [ $(SIMULATOR) != "questa" ];then \
 		echo "unknown simulator=$SIMULATOR"; \
 		exit 1; \
 	fi
@@ -111,7 +111,7 @@ check_snap_settings:
 	fi
 
 check_denali:
-	@if [ $(NVME_USED) == "TRUE" ]; then \
+	@if [ $(NVME_USED) = "TRUE" ]; then \
 		if [ !  -d "$(DENALI_TOOLS)" ] || [ ! -d "$(DENALI_CUSTOM)" ]; then \
 			echo "Missing one or more environment variables for NVMe simulation."; \
 			echo "Please check the following variables."; \
@@ -195,7 +195,7 @@ patch_version:
 	$(SNAP_HARDWARE_ROOT)/setup/patch_version.sh $(SNAP_HDL_CORE) snap_core_types.vhd
 
 patch_NVMe:
-	@if [[ -e "$(SNAP_HARDWARE_ROOT)/setup/patch_NVMe.sh" && $(NVME_USED) = "TRUE" ]]; then \
+	@if [ -e "$(SNAP_HARDWARE_ROOT)/setup/patch_NVMe.sh" ] && [ $(NVME_USED) = "TRUE" ]; then \
 		cd $(SNAP_HARDWARE_ROOT)/setup && ./patch_NVMe.sh && cd .. ; \
 		echo -e "\t[PATCH...............] NVMe PCIe Root Complex sim. files"; \
 	fi


### PR DESCRIPTION
Bashisms like "[[ ... ]]" and comparisons with "==" were replaced with sh-compatible expressions.

Signed-off-by: Balthasar Martin <balthasar.martin@student.hpi.de>