### PR TITLE
SW: allow c99 for example code

### DIFF
--- a/software/config.mk
+++ b/software/config.mk
@@ -85,7 +85,7 @@ VERSION:=$(VERSION)-$(GIT_BRANCH)
 endif
 
 CFLAGS ?= -W -Wall -Werror -Wwrite-strings -Wextra -O2 -g \
-	-Wmissing-prototypes -std=c99 # -Wstrict-prototypes -Warray-bounds
+	-Wmissing-prototypes # -Wstrict-prototypes -Warray-bounds
 CFLAGS += -DGIT_VERSION=\"$(VERSION)\" \
 	-I. -I../include -D_GNU_SOURCE=1
 

--- a/software/config.mk
+++ b/software/config.mk
@@ -85,7 +85,7 @@ VERSION:=$(VERSION)-$(GIT_BRANCH)
 endif
 
 CFLAGS ?= -W -Wall -Werror -Wwrite-strings -Wextra -O2 -g \
-	-Wmissing-prototypes # -Wstrict-prototypes -Warray-bounds
+	-Wmissing-prototypes -std=c99 # -Wstrict-prototypes -Warray-bounds
 CFLAGS += -DGIT_VERSION=\"$(VERSION)\" \
 	-I. -I../include -D_GNU_SOURCE=1
 

--- a/software/examples/Makefile
+++ b/software/examples/Makefile
@@ -16,6 +16,7 @@
 
 include ../config.mk
 
+CFLAGS += -std=c99
 DESTDIR ?= /usr
 libs = ../lib/libsnap.a
 LDLIBS += $(libs) -lpthread


### PR DESCRIPTION
Using CFLAGS += -std=c99 was not working yet for the library due to a union without a name defined in cxl.h. So using it for the example applications only is the only thing working yet. I talked to Frederic Barrat to have a look.