### PR TITLE
Build/SW: Fixing clean rule for example actions, using -funroll-all-loops to build example code

### DIFF
--- a/hardware/action_examples/Makefile
+++ b/hardware/action_examples/Makefile
@@ -16,20 +16,24 @@
 
 subdirs += $(wildcard hls_*) $(wildcard hdl_*)
 
+# Build all subdirs is normally not needed, but useful to check if
+# all HLS code synthesizes well.
 all: $(subdirs)
 
-# Only build if the subdirectory is really existent
+# Only build if the subdirectory is existent and if Makefile is there
 .PHONY: $(subdirs)
 $(subdirs):
-	@if [ -d $@ ]; then				\
-		$(MAKE) -C $@ || exit 1;		\
+	@if [ -d $@ -a -f $@/Makefile ]; then			\
+		$(MAKE) -C $@ || exit 1;			\
 	fi
 
+# Cleanup for all subdirectories.
+# Only dive into subdirectory if existent and if Makefile is there.
 clean:
-	@for dir in $(subdirs); do	\
-		if [ -d $$dir ]; then			\
-			$(MAKE) -C $$dir $@ || exit 1;	\
-		fi					\
+	@for dir in $(subdirs); do				\
+		if [ -d $$dir -a -f $$dir/Makefile ]; then	\
+			$(MAKE) -C $$dir $@ || exit 1;		\
+		fi						\
 	done
 	@find . -depth -name '*~'  -exec rm -rf '{}' \; -print
 	@find . -depth -name '.#*' -exec rm -rf '{}' \; -print

--- a/hardware/action_examples/Makefile
+++ b/hardware/action_examples/Makefile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-subdirs += $(wildcard hls_*)
+subdirs += $(wildcard hls_*) $(wildcard hdl_*)
 
 all: $(subdirs)
 
@@ -26,7 +26,7 @@ $(subdirs):
 	fi
 
 clean:
-	@for dir in $(subdirs) $(hardware_subdirs); do	\
+	@for dir in $(subdirs); do	\
 		if [ -d $$dir ]; then			\
 			$(MAKE) -C $$dir $@ || exit 1;	\
 		fi					\

--- a/software/config.mk
+++ b/software/config.mk
@@ -86,8 +86,12 @@ endif
 
 CFLAGS ?= -W -Wall -Werror -Wwrite-strings -Wextra -O2 -g \
 	-Wmissing-prototypes # -Wstrict-prototypes -Warray-bounds
+
 CFLAGS += -DGIT_VERSION=\"$(VERSION)\" \
 	-I. -I../include -D_GNU_SOURCE=1
+
+# Optimizations
+CFLAGS += -funroll-all-loops
 
 # Force 32-bit build
 #   This is needed to generate the code for special environments. We have


### PR DESCRIPTION
Same as old branch, but not changing the test stuff.
Added -funroll-all-loops to speed up test-applications.
I wonder where my platform specific optimisations ended up ...