### PR TITLE
Check snap_example tools Input parameter.

### DIFF
--- a/actions/hdl_example/sw/snap_example.c
+++ b/actions/hdl_example/sw/snap_example.c
@@ -244,7 +244,8 @@ static int memcpy_test(struct snap_card* dnc,
 		return 1;
 	}
 	if (align > DEFAULT_MEMCPY_BLOCK) {
-		VERBOSE0("align=%d is to much for me\n", align);
+		VERBOSE0("align: %d is to much for me. Max: %d\n",
+			align, DEFAULT_MEMCPY_BLOCK);
 		return 1;
 	}
 


### PR DESCRIPTION
Added some code for input parameter test. Example code can only be used on a 
64 Byte boundary.
 
Signed-off-by: Eberhard S. Amann <esa@de.ibm.com>