### PR TITLE
PR Flow: DCP_ROOT not exported using full path

### DIFF
--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -22,7 +22,7 @@
 ## This Makefile is contained in the hardware directory.
 ## So, the root directory is one level above.
 ##
-export SNAP_ROOT=$(abspath ..)
+export SNAP_ROOT=$(shell pwd)/..
 export SNAP_HARDWARE_ROOT=$(SNAP_ROOT)/hardware
 export LOGS_DIR=$(SNAP_HARDWARE_ROOT)/logs
 

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -22,7 +22,7 @@
 ## This Makefile is contained in the hardware directory.
 ## So, the root directory is one level above.
 ##
-export SNAP_ROOT=$(shell pwd)/..
+export SNAP_ROOT=$(abspath ..)
 export SNAP_HARDWARE_ROOT=$(SNAP_ROOT)/hardware
 export LOGS_DIR=$(SNAP_HARDWARE_ROOT)/logs
 

--- a/snap_env
+++ b/snap_env
@@ -124,7 +124,7 @@ while [ -z "$SETUP_DONE" ]; do
 
   if [ "$USE_PRFLOW" = "TRUE" ]; then
     if [ -z "$DCP_ROOT" ]; then
-      export DCP_ROOT='${SNAP_ROOT}/dcp'
+      export DCP_ROOT=$snapdir/dcp
       echo "Setting DCP_ROOT               to: \"$DCP_ROOT\""
       mkdir -p $snapdir/dcp
     else


### PR DESCRIPTION
abspath does not work correctly with `make -C`
