### PR TITLE
Cloning kconfig from github if necessary

### DIFF
--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,2 @@
+kconfig
+build

--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -36,7 +36,9 @@ config FPGACHIP
 config NUM_OF_ACTIONS
         int
         default 1
-        prompt "Number Of Actions"
+# as long as only one action is supported we do not need to prompt the number of actions
+# prompt should be enabled as soon as multiple action support is implemented
+#        prompt "Number Of Actions"
         range 1 1
         help
           SNAP currently supports one action.

--- a/scripts/snap_cfg
+++ b/scripts/snap_cfg
@@ -17,6 +17,7 @@
 
 version=1.0
 program=`basename "$0"`
+prgdir=$(dirname $(readlink -f "$BASH_SOURCE")) # path containing this script
 
 # output formatting
 bold=$(tput bold)
@@ -24,6 +25,7 @@ normal=$(tput sgr0)
 
 # Name of global config file
 kconfig="`pwd`/Kconfig"
+kconfig_dir="`pwd`/kconfig"
 snap_config=../.snap_config
 snap_config_sh=../.snap_config.sh
 snap_config_cflags=../.snap_config.cflags
@@ -31,6 +33,9 @@ autoconf=../software/include/autoconf.h
 linux_dir="/usr/src/kernels/`uname -r`"
 build_dir="`pwd`/build"
 option=menuconfig
+if [ -e $linux_dir ]; then
+  kconfig_dir=$linux_dir
+fi
 
 # Print usage message helper function
 function usage() {
@@ -82,18 +87,34 @@ shift $((OPTIND-1))
 # now do something with $@
 
 echo "SNAP Build Options"
-echo "  Linux:    $linux_dir"
-echo "  Build:    $build_dir"
-echo "  Kconfig:  $kconfig"
-echo "  config:   $snap_config"
-echo "  autoconf: $autoconf"
+echo "  linux_dir:   $linux_dir"
+echo "  kconfig_dir: $kconfig_dir"
+echo "  Build:       $build_dir"
+echo "  Kconfig:     $kconfig"
+echo "  config:      $snap_config"
+echo "  autoconf:    $autoconf"
+
+if [ ! -e $kconfig_dir ]; then
+  echo "Cloning kconfig from github.com/guillon/kconfig into $kconfig_dir"
+  git clone https://github.com/guillon/kconfig $kconfig_dir
+fi
 
 mkdir -p $build_dir
-cmd="make -C $linux_dir O=$build_dir KBUILD_KCONFIG=$kconfig $option"
+if [ "$kconfig_dir" != "$linux_dir" ]; then
+  cmd="make -f $kconfig_dir/GNUmakefile TOPDIR=. SRCDIR=kconfig KBUILD_KCONFIG=$kconfig $option"
+else
+  cmd="make -C $kconfig_dir O=$build_dir KBUILD_KCONFIG=$kconfig $option"
+fi
 
 echo "Executing:"
 echo "  $cmd"
+pushd $prgdir
 $cmd
+popd
+
+if [ "$kconfig_dir" != "linux_dir" ]; then
+  mv -f $prgdir/config $build_dir/.config
+fi
 
 echo "Generating SNAP config files $snap_config, $snap_config_sh and $snap_config_cflags ..."
 cp $build_dir/.config $snap_config


### PR DESCRIPTION
This pull request replaces #442 because a rebase became necessary. 
This pull request is an attempt to fix issue #438 by cloning a standalone kconfig support from github if the Linux kernel sources are not installed.

**Note:** If `menuconfig` does not work due to missing ncurses support, `oldconfig` may be used instead.
In this case `oldconfig` should be the first target to be addressed in the make process.
I.e. instead of calling `make image` (or `make model`) you should call `make oldconfig image` or `make oldconfig model`.