### PR TITLE
build: fixed set_false_path for the nvme_reset_n_q signal

### DIFF
--- a/hardware/setup/FGT/snap_nvme.xdc
+++ b/hardware/setup/FGT/snap_nvme.xdc
@@ -19,7 +19,8 @@
 ############################################################################
 
 ## 
-set_false_path -from [get_ports sys_rst_n]
+set_false_path -from [get_pins nvme_reset_n_q*/C] -to [get_clocks pcie_clk?]
+
 # ------------------------------
 # Pin Locations & I/O Standards
 # ------------------------------


### PR DESCRIPTION
The statement set_false_path -from [get_ports sys_rst_n] in snap_nvme.xdc is no longer valid and causes critical warnings in the log files. I replaced the set_false_path by a valid on.
set_false_path -from [get_pins nvme_reset_n_q*/C] -to [get_clocks pcie_clk?]

Signed-off-by: Thomas Fuchs <thomas.fuchs@de.ibm.com>