### PR TITLE
Config: Support for "static" variables in .snap_env.sh

### DIFF
--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -257,7 +257,7 @@ create_environment:
 	@echo -e "                        using `vivado -version |grep Vivado`"
 	@cd $(SNAP_HARDWARE_ROOT)/setup                                          && vivado -quiet -mode batch -source create_ip.tcl        -notrace -log $(LOGS_DIR)/create_ip.log         -journal $(LOGS_DIR)/create_ip.jou
 	@if [ $(NVME_USED) = "TRUE" ]; then cd $(SNAP_HARDWARE_ROOT)/setup       && vivado -quiet -mode batch -source create_nvme_host.tcl -notrace -log $(LOGS_DIR)/create_nvme_host.log  -journal $(LOGS_DIR)/create_nvme_host.jou; fi
-	@eval ILA_SETUP_FILE=$(ILA_SETUP_FILE) && cd $(SNAP_HARDWARE_ROOT)/setup && vivado -quiet -mode batch -source create_framework.tcl -notrace -log $(LOGS_DIR)/create_framework.log  -journal $(LOGS_DIR)/create_framework.jou
+	@eval ACTION_ROOT=$(ACTION_ROOT) && eval PSL_DCP=$(PSL_DCP) && eval ILA_SETUP_FILE=$(ILA_SETUP_FILE) && cd $(SNAP_HARDWARE_ROOT)/setup && vivado -quiet -mode batch -source create_framework.tcl -notrace -log $(LOGS_DIR)/create_framework.log  -journal $(LOGS_DIR)/create_framework.jou
 	@echo -e "[CREATE_ENVIRONMENT..] done  `date +"%T %a %b %d %Y"`"
 
 config_start:

--- a/scripts/snap_cfg
+++ b/scripts/snap_cfg
@@ -103,6 +103,7 @@ $cmd
 echo "Generating SNAP config files $snap_config, $snap_config_sh and $snap_config_cflags ..."
 cp $build_dir/.config $snap_config
 cat $snap_config | sed 's/^CONFIG_/export /' | tr -d '"' > $snap_config_sh
+chmod +x $snap_config_sh
 cat $snap_config | tr -d '"' | sed 's/^CONFIG_\(.*\)/SNAP_CFLAGS += "-DCONFIG_\1"/' > $snap_config_cflags
 echo "Generation of SNAP config files done."
 

--- a/snap_env
+++ b/snap_env
@@ -26,12 +26,13 @@ snap_env_sh=$snapdir/.snap_env.sh
 unset PSL_DCP
 unset ACTION_ROOT
 unset PSLSE_ROOT
+unset ILA_SETUP_FILE
 unset DCP_ROOT
-if [ -f "$1" ]; then
-  source $1
+if [ -e "$snap_env_sh" ]; then
+  source $snap_env_sh
 fi
-if [ -f "$snap_env_sh" ]; then
-  source "$snap_env_sh"
+if [ -e "$1" ]; then
+  source $1
 fi
 
 unset SETUP_DONE
@@ -66,7 +67,7 @@ while [ -z "$SETUP_DONE" ]; do
   ####### checking path to PSL design checkpoint
   echo "=====Checking path to PSL design checkpoint============"
   echo "PSL_DCP                 is set to: \"$PSL_DCP\""
-  SNAP_ENV="$SNAP_ENV""export PSL_DCP=$PSL_DCP\n"
+  SNAP_ENV="$SNAP_ENV""export PSL_DCP='$PSL_DCP'\n"
   if [ -f "$PSL_DCP" ]; then
     # checking card type for PSL design checkpoint
     PSL_DCP_TYPE=`$snapdir/hardware/snap_check_psl $PSL_DCP`
@@ -106,7 +107,7 @@ while [ -z "$SETUP_DONE" ]; do
     AR='${SNAP_ROOT}/actions/hls_nvme_memcopy'
   fi
   if [ -z "$AR" ]; then
-    AR=$ACTION_ROOT
+    AR='$ACTION_ROOT'
     echo "ACTION_ROOT             is set to: \"$ACTION_ROOT\""
     if [ ! -d "$ACTION_ROOT" ] && ( ( [ -z `echo "x$ACTION_ROOT" | grep -i /HLS` ] && [ "${HLS_SUPPORT^^}" != "TRUE" ] ) || [ `basename "x$ACTION_ROOT"` != "vhdl" ] ); then
       SETUP_WARNING="$SETUP_WARNING\n### WARNING ### Please make sure that ACTION_ROOT points to an existing directory."
@@ -118,7 +119,7 @@ while [ -z "$SETUP_DONE" ]; do
   fi
 
   if [ -n "$AR" ]; then
-    SNAP_ENV="$SNAP_ENV""export ACTION_ROOT=$AR\n"
+    SNAP_ENV="$SNAP_ENV""export ACTION_ROOT='$AR'\n"
   fi
 
 
@@ -208,6 +209,7 @@ while [ -z "$SETUP_DONE" ]; do
 
   if [ -n "$SNAP_ENV" ]; then
     echo -e "$SNAP_ENV" > $snap_env_sh
+    chmod +x $snap_env_sh
   fi
   echo
 


### PR DESCRIPTION
With this change it is possible to define paths and other environment variables in `.snap_env.sh` in a way that they contain config variables that will be replaced with their values only in the evaluation within the make process.
In order to make these definitions persistent, single quotes are required. For example:
'''
    export PSL_DCP='/afs/xyz/cards/${FPGACARD}/current/b_route_design.dcp'
'''