### PR TITLE
Makefile: Help message as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,24 @@ snap_env_sh = snap_env.sh
 clean_subdirs += $(config_subdirs) $(software_subdirs) $(hardware_subdirs) $(action_subdirs)
 
 # Only build if the subdirectory is really existent
-.PHONY: $(software_subdirs) software $(action_subdirs) actions $(hardware_subdirs) hardware test install uninstall snap_env hw_config model image cloud_base cloud_action cloud_merge snap_config config menuconfig xconfig gconfig oldconfig clean clean_config clean_env
+.PHONY: help $(software_subdirs) software $(action_subdirs) actions $(hardware_subdirs) hardware test install uninstall snap_env hw_config model image cloud_base cloud_action cloud_merge snap_config config menuconfig xconfig gconfig oldconfig clean clean_config clean_env
+
+help:
+	@echo "Main targets for the SNAP Framework make process:";
+	@echo "=================================================";
+	@echo "* snap_config    Configure SNAP framework";
+	@echo "* model          Build simulation model for simulator specified via target snap_config";
+	@echo "* image          Build a complete FPGA bitstream (will take more than one hour)";
+	@echo "* hardware       Build simulation model and FPGA bitstream (combines targets 'model' and 'image')";
+	@echo "* software       Build software libraries and tools for SNAP";
+	@echo "* actions        Build the applications for all actions";
+	@echo "* clean          Remove all files generated in make process";
+	@echo "* clean_config   As target 'clean' plus reset of the configuration";
+	@echo "* help           Print this message";
+	@echo;
+	@echo "The hardware related targets 'model', 'image' and 'hardware'";
+	@echo "do only exist on an x86 platform";
+	@echo;
 
 ifeq ($(PLATFORM),x86_64)
 all: $(software_subdirs) $(action_subdirs) $(hardware_subdirs)
@@ -57,13 +74,6 @@ $(action_subdirs):
 
 actions: $(action_subdirs)
 
-$(hardware_subdirs): $(snap_env_sh)
-	@if [ -d $@ ]; then              \
-	    $(MAKE) -s -C $@ || exit 1;  \
-	fi
-
-hardware: $(hardware_subdirs)
-
 # Install/uninstall
 test install uninstall:
 	@for dir in $(software_subdirs) $(action_subdirs); do \
@@ -72,6 +82,14 @@ test install uninstall:
 	    fi                                                \
 	done
 
+ifeq ($(PLATFORM),x86_64)
+$(hardware_subdirs): $(snap_env_sh)
+	@if [ -d $@ ]; then              \
+	    $(MAKE) -s -C $@ || exit 1;  \
+	fi
+
+hardware: $(hardware_subdirs)
+
 # Model build and config
 hw_config model image cloud_base cloud_action cloud_merge: $(snap_env_sh)
 	@for dir in $(hardware_subdirs); do                \
@@ -79,6 +97,7 @@ hw_config model image cloud_base cloud_action cloud_merge: $(snap_env_sh)
 	        $(MAKE) -s -C $$dir $@ || exit 1;          \
 	    fi                                             \
 	done
+endif
 
 # SNAP Config
 config menuconfig xconfig gconfig oldconfig:

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,14 @@ hw_config model image cloud_base cloud_action cloud_merge: $(snap_env_sh)
 	        $(MAKE) -s -C $$dir $@ || exit 1;          \
 	    fi                                             \
 	done
+
+else #noteq ($(PLATFORM),x86_64)
+.PHONY: wrong_platform
+
+wrong_platform:
+	@echo; echo "\nSNAP hardware builds are possible on x86 platform only\n"; echo;
+
+$(hardware_subdirs) hardware hw_config model image cloud_base cloud_action cloud_merge: wrong_platform
 endif
 
 # SNAP Config

--- a/actions/Makefile
+++ b/actions/Makefile
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+PLATFORM ?= $(shell uname -i)
 
 subdirs += $(wildcard hls_*) $(wildcard hdl_*)
 software_subdirs = $(addsuffix /sw,$(subdirs))
@@ -27,7 +28,9 @@ software:
 
 software_all: $(software_subdirs)
 
+ifeq ($(PLATFORM),x86_64)
 hardware_all: $(hardware_subdirs)
+endif
 
 # Only build if the subdirectory is existent and if Makefile is there
 .PHONY: $(software_subdirs) $(hardware_subdirs)
@@ -41,7 +44,8 @@ $(software_subdirs): software
 		echo "INFO: No Makefile available in $@ ...";	\
 	fi
 
-$(hardware_subdirs): 
+ifeq ($(PLATFORM),x86_64)
+$(hardware_subdirs):
 	@if [ -d $@ -a -f $@/Makefile ]; then			\
 		echo "Enter: $@";                               \
 		$(MAKE) -C $@ || exit 1;			\
@@ -49,6 +53,7 @@ $(hardware_subdirs):
 	else							\
 		echo "INFO: No Makefile available in $@ ...";	\
 	fi
+endif
 
 test:
 	@echo "Noting to be done here yet."

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -388,9 +388,12 @@ gitclean:
 	@echo -e "[GITCLEAN............] cleaning and resetting snap git";
 	git clean -f -d -x
 	git reset --hard
-else
-.PHONY wrong_plattform all model image
-wrong_plattform:
 
-all model image: wrong_plattform
+else #noteq ($(PLATFORM),x86_64)
+.PHONY: wrong_platform all model image
+
+wrong_platform:
+	@echo; echo "\nSNAP hardware builds are possible on x86 platform only\n"; echo;
+
+all model image: wrong_platform
 endif

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -22,6 +22,9 @@
 ## This Makefile is contained in the hardware directory.
 ## So, the root directory is one level above.
 ##
+PLATFORM ?= $(shell uname -i)
+
+ifeq ($(PLATFORM),x86_64)
 export SNAP_ROOT=$(abspath ..)
 export SNAP_HARDWARE_ROOT=$(SNAP_ROOT)/hardware
 export LOGS_DIR=$(SNAP_HARDWARE_ROOT)/logs
@@ -34,6 +37,7 @@ snap_env_sh        = $(SNAP_ROOT)/snap_env.sh
 -include $(snap_config_sh)
 -include $(snap_env_sh)
 
+SIMULATOR ?= nosim
 ifeq "$(FPGACARD)" "KU3"
 	export DDR3_USED=$(SDRAM_USED)
 	export DDR4_USED=FALSE
@@ -93,7 +97,7 @@ SNAP_BASE_DCP=$(DCP_ROOT)/snap_static_region_bb.dcp
 
 .PHONY: all snap_config check_snap_settings check_psl_dcp check_simulator check_nvme prepare_build snap_preprocess_start snap_preprocess patch_version patch_NVMe action_hw create_environment hw_config_start hw_config config image cloud_base cloud_action cloud_merge pslse software action_sw model xsim irun nosim clean gitclean
 
-all: hw_config model image
+all: model image
 
 snap_config:
 	@$(MAKE) -C $(SNAP_ROOT) snap_config
@@ -269,7 +273,11 @@ image: .hw_config_done check_snap_settings snap_preprocess patch_version
 	@if [ `echo "$(USE_PRFLOW)" | tr a-z A-Z` = "TRUE" ]; then \
 		echo -e "                        Makefile target $@ not allowed for PR flow!"; exit -1; \
 	fi
-	@echo -e "[BUILD IMAGE.........] start `date +"%T %a %b %d %Y"`"
+	@echo -e "[BUILD IMAGE.........] start `date +"%T %a %b %d %Y"`\n"
+	@echo "A complete FPGA bitstream build got kicked off.";
+	@echo "This will take more than an hour.";
+	@echo "The process may be terminated by pressing <CTRL>-C at any time.";
+	@echo -e "After termination it can be restarted later.\n"
 	@cd $(BUILD_DIR) && vivado -quiet -mode batch -source snap_build.tcl -notrace -log $(LOGS_DIR)/snap_build.log -journal $(LOGS_DIR)/snap_build.jou
 	@$(RM) -r .bitstream_name.txt
 	@echo -e "[BUILD IMAGE.........] done  `date +"%T %a %b %d %Y"`"
@@ -380,3 +388,9 @@ gitclean:
 	@echo -e "[GITCLEAN............] cleaning and resetting snap git";
 	git clean -f -d -x
 	git reset --hard
+else
+.PHONY wrong_plattform all model image
+wrong_plattform:
+
+all model image: wrong_plattform
+endif

--- a/snap_env
+++ b/snap_env
@@ -104,20 +104,22 @@ while [ -z "$SETUP_DONE" ]; do
   fi
 
 
-  ####### checking path to PSLSE
-  echo "=====Simulation setup: Checking path to PSLSE=========="
-  echo "PSLSE_ROOT              is set to: \"$PSLSE_ROOT\""
-  RESP=`grep PSLSE_ROOT $snap_env_sh`
-  if [ -z "$RESP" ]; then
-    echo "export PSLSE_ROOT=" >> $snap_env_sh
-  fi
-  if [ -z "$PSLSE_ROOT" ]; then
-    SETUP_EMPTY="$SETUP_EMPTY\n  PSLSE_ROOT"
-  elif [ ! -d "$PSLSE_ROOT" ]; then
-    SETUP_WARNING="$SETUP_WARNING\n### WARNING ### Path to PSLSE not set properly."
-    SETUP_WARNING="$SETUP_WARNING\n    For simulation please clone PSL Simulation Environment"
-    SETUP_WARNING="$SETUP_WARNING\n    from https://github.com/ibm-capi/pslse"
-    SETUP_WARNING="$SETUP_WARNING\n    and let \$PSLSE_ROOT point to it"
+  ####### checking path to PSLSE (only if simulation is enabled)
+  if [ $SIMULATOR != "nosim" ]; then
+    echo "=====Simulation setup: Checking path to PSLSE=========="
+    echo "PSLSE_ROOT              is set to: \"$PSLSE_ROOT\""
+    RESP=`grep PSLSE_ROOT $snap_env_sh`
+    if [ -z "$RESP" ]; then
+      echo "export PSLSE_ROOT=" >> $snap_env_sh
+    fi
+    if [ -z "$PSLSE_ROOT" ]; then
+      SETUP_EMPTY="$SETUP_EMPTY\n  PSLSE_ROOT"
+    elif [ ! -d "$PSLSE_ROOT" ]; then
+      SETUP_WARNING="$SETUP_WARNING\n### WARNING ### Path to PSLSE not set properly."
+      SETUP_WARNING="$SETUP_WARNING\n    For simulation please clone PSL Simulation Environment"
+      SETUP_WARNING="$SETUP_WARNING\n    from https://github.com/ibm-capi/pslse"
+      SETUP_WARNING="$SETUP_WARNING\n    and let \$PSLSE_ROOT point to it"
+    fi
   fi
 
 


### PR DESCRIPTION
This change addresses issue #449.
It additionally disables all hardware related targets on non-x86 machines.
On the start of an image build, a message is printed that this will take a while and that the process may be terminated by pressing <CTRL>-C.
Furthermore, calling `make model` directly from the hardware directory w/o a previous configuration via `make snap_config` will now assume `SIMULATOR=nosim` and therefore won't do anything.