### PR TITLE
Kconfig advanced settings

### DIFF
--- a/ActionTypes.md
+++ b/ActionTypes.md
@@ -4,7 +4,7 @@ Vendor | Range Start | Range End | Description
 Reserved | 00.00.00.00 | 00.00.00.00 | Reserved
 free | 00.00.00.01 | 00.00.FF.FF | Free for experimental use
 IBM | 10.14.00.00 | 10.14.00.00 | SNAP framework example
-IBM | 10.14.00.01 | 10.14.00.01 | HDL NVMe example (only for Nallatech 250S card)
+IBM | 10.14.00.01 | 10.14.00.01 | HDL NVMe example
 IBM | 10.14.00.02 | 10.14.0F.FF | Reserved for IBM Actions
 IBM | 10.14.10.00 | 10.14.10.00 | HLS Memcopy
 IBM | 10.14.10.01 | 10.14.10.01 | HLS Sponge
@@ -12,13 +12,22 @@ IBM | 10.14.10.02 | 10.14.10.02 | HLS HashJoin
 IBM | 10.14.10.03 | 10.14.10.03 | HLS Text Search
 IBM | 10.14.10.04 | 10.14.10.04 | HLS BFS (Breadth First Search)
 IBM | 10.14.10.05 | 10.14.10.06 | HLS Intersection (Two methods)
-IBM | 10.14.10.07 | 10.14.10.07 | HLS NVMe memcopy (only for Nallatech 250S card)
+IBM | 10.14.10.07 | 10.14.10.07 | HLS NVMe memcopy
 IBM | 10.14.10.08 | 10.14.10.08 | HLS Hello World
 IBM | 10.14.10.09 | 10.14.FF.FF | Reserved for IBM Actions
 Reserved | FF.FF.00.00 | FF.FF.FF.FF | Reserved
 
 ### How to apply for a new Action Type
 
-With every line in the table above a range of Action Type IDs is being reserved for a specific vendor or the range is defined as *reserved* (not to be used) or as *free* (for experimental use).
+With every line in the table above a range of Action Type IDs is
+being reserved for a specific vendor or the range is defined as
+*reserved* (not to be used) or as *free* (for experimental use).
 
-Each new action type should get a unique number. The number is defined as pair of 16-bit vendor and 16-bit action id. To obtain a number, please add the new action type in the table above. Create a git pull request and get it approved and included (see instructions in [./CONTRIBUTING.md](./CONTRIBUTING.md). By following this procedure duplicate action types will be avoided. For the first 16 bit of your action types you may use your own 16-bit vendor id.
+Each new action type should get a unique number.
+The number is defined as pair of 16-bit vendor and 16-bit action id.
+To obtain a number, please add the new action type in the table above.
+Create a git pull request and get it approved and included
+(see instructions in [./CONTRIBUTING.md](./CONTRIBUTING.md).
+By following this procedure duplicate action types will be avoided.
+For the first 16 bit of your action types you may use your own 16-bit
+vendor id.

--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -146,7 +146,7 @@ config ENABLE_BRAM
         prompt "Enable BRAM (replacing SDRAM for experimental use)"
         depends on ! DISABLE_SDRAM_AND_BRAM
         help
-          This is a debug option. The AXI attached on-card SDRAM will be replaced by 512KB BRAM.
+          This is a development option. The AXI attached on-card SDRAM will be replaced by 512KB BRAM.
 
 config BRAM_USED
         string

--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -128,18 +128,6 @@ config FORCE_SDRAM
         depends on (FORCE_SDRAM_OR_BRAM && ! ENABLE_BRAM)
         select ENABLE_SDRAM
 
-config ENABLE_BRAM
-        bool
-        prompt "Enable BRAM (replacing SDRAM for debug)"
-        depends on ! DISABLE_SDRAM_AND_BRAM
-        help
-          This is a debug option. The AXI attached on-card SDRAM will be replaced by 512KB BRAM.
-
-config BRAM_USED
-        string
-        default "TRUE"  if ENABLE_BRAM
-        default "FALSE" if ! ENABLE_BRAM
-
 config ENABLE_SDRAM
         bool
         prompt "Enable SDRAM"
@@ -152,6 +140,18 @@ config SDRAM_USED
         string
         default "TRUE"  if ENABLE_SDRAM
         default "FALSE" if ! ENABLE_SDRAM
+
+config ENABLE_BRAM
+        bool
+        prompt "Enable BRAM (replacing SDRAM for experimental use)"
+        depends on ! DISABLE_SDRAM_AND_BRAM
+        help
+          This is a debug option. The AXI attached on-card SDRAM will be replaced by 512KB BRAM.
+
+config BRAM_USED
+        string
+        default "TRUE"  if ENABLE_BRAM
+        default "FALSE" if ! ENABLE_BRAM
 
 config ENABLE_DDR3
         bool
@@ -200,27 +200,6 @@ config NVME_USED
         default "TRUE"  if ENABLE_NVME
         default "FALSE" if ! ENABLE_NVME
 
-config ENABLE_ILA
-        bool "Enable ILA Debug (Definition of $ILA_SETUP_FILE required)"
-        help
-          Enable the usage of Vivado's integrated logic analyzer.
-          Please make sure that $ILA_SETUP_FILE points to the .xdc file
-          defining the debug cores.
-
-config ILA_DEBUG
-        string
-        default "TRUE"  if ENABLE_ILA
-        default "FALSE" if ! ENABLE_ILA
-
-config ENABLE_FACTORY
-        bool "Create Factory Image"
-
-config FACTORY_IMAGE
-        string
-        default "TRUE"  if ENABLE_FACTORY
-        default "FALSE" if ! ENABLE_FACTORY
-
-
 choice
         bool "Simulator"
         default SIM_XSIM
@@ -247,6 +226,28 @@ config SIMULATOR
         default "xsim"  if SIM_XSIM
         default "irun"  if SIM_IRUN
         default "nosim" if NO_SIM
+
+comment "================= Advanced Options: ================="
+
+config ENABLE_ILA
+        bool "Enable ILA Debug (Definition of $ILA_SETUP_FILE required)"
+        help
+          Enable the usage of Vivado's integrated logic analyzer.
+          Please make sure that $ILA_SETUP_FILE points to the .xdc file
+          defining the debug cores.
+
+config ILA_DEBUG
+        string
+        default "TRUE"  if ENABLE_ILA
+        default "FALSE" if ! ENABLE_ILA
+
+config ENABLE_FACTORY
+        bool "Create Factory Image"
+
+config FACTORY_IMAGE
+        string
+        default "TRUE"  if ENABLE_FACTORY
+        default "FALSE" if ! ENABLE_FACTORY
 
 config ENABLE_PRFLOW
         bool "Cloud build"


### PR DESCRIPTION
I did not find a way to create a dependency between ENABLE_SDRAM and ENABLE_BRAM such that both options are always visible but only one of them is selectable.
Note: Additionally to the Kconfig changes I also modified ActionTypes.md since kconfig is taking care of consistency in the selection of options.