### PR TITLE
Defconfig: Removed Makefile Error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,8 @@ $(snap_env_sh) snap_env: $(snap_config_sh)
 	fi
 	@cp defconfig/$@ $(snap_config)
 	@$(MAKE) -s oldconfig
-	@$(MAKE) -s snap_env
+	@$(MAKE) -s snap_env snap_env_parm=config
+	@echo "SNAP defconfig done"
 
 clean:
 	@for dir in $(clean_subdirs); do           \


### PR DESCRIPTION
`make ADKU3.SDRAM.XSIM.PRFLOW.hls_memcopy.defconfig` was throwing an Error after running the snap_env script

- Added snap_env_parm for defconfig Make recipe 

