### PR TITLE
ENV: Setting PATH in sim and adding snap_path.sh

### DIFF
--- a/hardware/sim/run_sim
+++ b/hardware/sim/run_sim
@@ -47,6 +47,7 @@
  export SNAP_ROOT=${PWD%/hardware/sim*};echo "root=$SNAP_ROOT"      # default root, in case its not overwritten
  [ -f "${SNAP_ROOT}/snap_env.sh" ]    && . ${SNAP_ROOT}/snap_env.sh
  [ -f "${SNAP_ROOT}/.snap_config.sh" ] && . ${SNAP_ROOT}/.snap_config.sh
+ export PATH=$PATH:$SNAP_ROOT/software/tools:$ACTION_ROOT/sw
 
  if [ -z $PSLSE_ROOT ];then echo "variable PSLSE_ROOT not found, leaving"; exit 11; fi
 

--- a/snap_path.sh
+++ b/snap_path.sh
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 ###############################################################################
+
+# This script needs to get sourced in order to effectively change $PATH
 export SNAP_ROOT=$(dirname $(readlink -f "$BASH_SOURCE"))
 [ -f "${SNAP_ROOT}/snap_env.sh" ] && . ${SNAP_ROOT}/snap_env.sh
 export PATH=$PATH:$SNAP_ROOT/software/tools:$ACTION_ROOT/sw

--- a/snap_path.sh
+++ b/snap_path.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Copyright 2016, International Business Machines
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+export SNAP_ROOT=$(dirname $(readlink -f "$BASH_SOURCE"))
+[ -f "${SNAP_ROOT}/snap_env.sh" ] && . ${SNAP_ROOT}/snap_env.sh
+export PATH=$PATH:$SNAP_ROOT/software/tools:$ACTION_ROOT/sw


### PR DESCRIPTION
This change is meant to solve issue #502 by adding `$SNAP_ROOT/software/tools` and `$ACTION_ROOT/sw` to `$PATH` in simulation and via a script (`snap_path.sh`) that can be sourced by the user manually.
Should we add documentation for `snap_path.sh`? Where?