### PR TITLE
CBLK: NVMe Blocklayer with LBA pre-fetching updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+SHELL=/bin/bash
 PLATFORM ?= $(shell uname -i)
 
 export SNAP_ROOT=$(abspath .)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 PLATFORM ?= $(shell uname -i)
+
 export SNAP_ROOT=$(abspath .)
+
 config_subdirs += $(SNAP_ROOT)/scripts
 software_subdirs += $(SNAP_ROOT)/software
 hardware_subdirs += $(SNAP_ROOT)/hardware
@@ -58,18 +60,18 @@ endif
 %: %.sh
 
 $(software_subdirs):
-	@if [ -d $@ ]; then             \
+	if [ -d $@ ]; then             \
 	    echo "Enter: $@";           \
-	    $(MAKE) -s -C $@ || exit 1; \
+	    $(MAKE) -C $@ || exit 1; \
 	    echo "Exit:  $@";           \
 	fi
 
 software: $(software_subdirs)
 
 $(action_subdirs):
-	@if [ -d $@ ]; then             \
+	if [ -d $@ ]; then             \
 	    echo "Enter: $@";           \
-	    $(MAKE) -s -C $@ || exit 1; \
+	    $(MAKE) -C $@ || exit 1; \
 	    echo "Exit:  $@";           \
 	fi
 

--- a/actions/hdl_nvme_example/README.md
+++ b/actions/hdl_nvme_example/README.md
@@ -1,3 +1,21 @@
-# README.md Example
+# SNAP NVMe Blocklayer
 
-Please put some more information here.
+The SNAP NVMe blocklayer provides a shared library which is compatible to the IBM CapiFLASH block API (https://github.com/open-power/capiflash). The SNAP version does not implement the entire API, but instead just the bare minimum: cblk_open, cblk_close, cblk_read, cblk_write and cblk_get_lun_size. Currently just one of the NVMe devices is supported.
+
+We created this library to explore potential performance improvements by doing transparent LBA prefetching. To get this working a small cache layer was added and, at this point in time, three pre-fetching strategies were added: UP, DOWN, UPDOWN. Also it is possible to set the number of LBAs per pre-fetch request and a threshold used to supress pre-fetching if the traffic on the NVMe device should be too high, such that pre-fetching would have negetive influence on the achievable performance of the solution.
+
+# NVMe Hardware Action
+
+The current hardware action supports 15 read request slots, which can be operated in parallel. There is one read-clear status register which is used to determine if a request has been successfully completed. There is just one write request slot, which might be a deficience to get maximum write throughput. The focus of this experiment was on exploring the behavior on reads.
+
+# Environment Variables to influence the behavior
+
+* CBLK_PREFETCH: Number of LBAs to be pre-fetched per block read request, prefetching implies that caching will be enabled
+* CBLK_STRATEGY: UP, DOWN, UPDOWN
+** UP: Fetching LBA + nblocks, LBA + 2 * nblocks, ...
+** DOWN: Fetching LBA - nblocks, LBA - 2 * nblocks, ...
+** UPDOWN: Fetching LBA - nblocks, LBA - 2 * nblocks, ..., LBA + nblocks, LBA + 2 * nblocks, ...
+* CBLK_NBLOCKS: nblocks for the pre-fetching strategy
+* CBLK_CACHING: 0 disables caching, for testing
+* CBLK_BUSYTIMEOUT: Time in sec for a request to stay on the busy semaphore (exceeding the 15 possible read requests)
+* CBLK_REQTIMEOUT: Timeout in sec for a hardware request to finish

--- a/actions/hdl_nvme_example/sw/Makefile
+++ b/actions/hdl_nvme_example/sw/Makefile
@@ -44,7 +44,10 @@ all: all_build
 ifdef BUILD_SIMCODE
 snap_cblk_libs += libsnapcblk.a
 else
-snap_cblk_LDFLAGS += -L.
+snap_cblk_LDFLAGS += -L. \
+	-Wl,-rpath,$(SNAP_ROOT)/actions/hdl_nvme_example/sw \
+	-Wl,-rpath,$(SNAP_ROOT)/software/lib
+
 snap_cblk_libs += -lsnapcblk
 endif
 
@@ -80,7 +83,8 @@ $(libnameB).so.$(MAJOR_VERSION): $(libnameB).so.$(libversion)
 
 $(libnameB).so.$(libversion): __$(libnameB).o
 	$(CC) $(LDFLAGS) -shared  $(SONAMEB) \
-		 -o $@ $^ $(libsB)
+		-Wl,-rpath,$(SNAP_ROOT)/software/lib \
+		-o $@ $^ $(libsB)
 
 projs += snap_nvme_example snap_cblk
 libs += $(projB)

--- a/actions/hdl_nvme_example/sw/Makefile
+++ b/actions/hdl_nvme_example/sw/Makefile
@@ -41,15 +41,15 @@ endif
 # Use rule defined in software.mk
 all: all_build
 
-ifdef BUILD_SIMCODE
-snap_cblk_libs += libsnapcblk.a
-else
+#ifdef BUILD_SIMCODE
+#snap_cblk_libs += libsnapcblk.a
+#else
 snap_cblk_LDFLAGS += -L. \
 	-Wl,-rpath,$(SNAP_ROOT)/actions/hdl_nvme_example/sw \
 	-Wl,-rpath,$(SNAP_ROOT)/software/lib
 
 snap_cblk_libs += -lsnapcblk -lrt
-endif
+#endif
 
 snap_cblk_objs += force_cpu.o
 

--- a/actions/hdl_nvme_example/sw/Makefile
+++ b/actions/hdl_nvme_example/sw/Makefile
@@ -63,7 +63,7 @@ projB = $(libnameB).a \
 	$(libnameB).so.$(libversion)
 
 snapblock_CPPFLAGS += -fPIC
-srcB = snapblock.c
+srcB = snapblock.c pp.c
 objsB = $(srcB:.c=.o)
 libsB += $(LDLIBS)
 

--- a/actions/hdl_nvme_example/sw/Makefile
+++ b/actions/hdl_nvme_example/sw/Makefile
@@ -63,6 +63,8 @@ projB = $(libnameB).a \
 	$(libnameB).so.$(libversion)
 
 snapblock_CPPFLAGS += -fPIC
+pp_CPPFLAGS += -fPIC
+
 srcB = snapblock.c pp.c
 objsB = $(srcB:.c=.o)
 libsB += $(LDLIBS)

--- a/actions/hdl_nvme_example/sw/Makefile
+++ b/actions/hdl_nvme_example/sw/Makefile
@@ -48,7 +48,7 @@ snap_cblk_LDFLAGS += -L. \
 	-Wl,-rpath,$(SNAP_ROOT)/actions/hdl_nvme_example/sw \
 	-Wl,-rpath,$(SNAP_ROOT)/software/lib
 
-snap_cblk_libs += -lsnapcblk
+snap_cblk_libs += -lsnapcblk -lrt
 endif
 
 snap_cblk_objs += force_cpu.o

--- a/actions/hdl_nvme_example/sw/pp.c
+++ b/actions/hdl_nvme_example/sw/pp.c
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2017 International Business Machines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Prefetch Predictor
+ *
+ * From a given sequence of LBAs (logical block addresses), we like
+ * to predict an optimal order of LBAs to be prefetched. That should
+ * help to reduce the latency needed to load the next LBA from an
+ * NVMe device.
+ *
+ * We tried positive and negative sequences, but we wondered if a
+ * sequence based on the history of requested LBAs can be of advantage.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/types.h>
+
+#include "pp.h"
+
+struct __lba {
+	off_t lba;
+	unsigned int nblocks;
+};
+
+struct __pp {
+	pthread_mutex_t lock;
+	int prefetch_count;
+	struct __lba *lba_list;	/* lba request history */
+	unsigned int lba_max;	/* maximum # of lba histrory */
+	unsigned int lba_ridx;	/* read index */
+	unsigned int lba_widx;	/* write index */
+};
+
+struct __pp pp;
+
+int pp_init(int strategy __attribute__((unused)),
+	int prefetch_count,
+	unsigned int lba_max)
+{
+	pp.lba_list = calloc(1, lba_max * sizeof(struct __lba));
+	if (!pp.lba_list)
+		return -1;
+	pp.prefetch_count = prefetch_count;
+
+	return 0;
+}
+void pp_done(void)
+{
+	if (pp.lba_list)
+		free(pp.lba_list);
+	pp.lba_list = NULL;
+}
+
+/*
+ * Every time a new LBA is requested, we need to be called to update
+ * our list of the last lba_max LBAs. This is required to calculate
+ * the optimal priolist every once in a while, e.g. every 1 sec.
+ *
+ * @p:         priority detector
+ * @lba:       requested LBA
+ * @nblocks:   how many blocks per LBA
+ */
+int pp_add_lba(off_t lba __attribute__((unused)),
+	size_t nblocks __attribute__((unused)))
+{
+	return 0;
+}
+
+/*
+ * The user is asked to update the priolist in a regular fashion such
+ * that the optimal prefetch sequence can be used.
+ *
+ * @p:         priority detector
+ * @priolist:  array of lba offsets e.g. -4, -2, 2, 4
+ * @n:         size of priorization list
+ */
+int pp_get_priolist(int *priolist, unsigned int n, size_t nblocks)
+{
+	unsigned int i;
+
+	for (i = 0; i < n; i++)
+		priolist[i] = (i - n/2) + nblocks * i;
+
+	return 0;
+}
+

--- a/actions/hdl_nvme_example/sw/pp.c
+++ b/actions/hdl_nvme_example/sw/pp.c
@@ -28,43 +28,48 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <pthread.h>
 #include <sys/types.h>
 
 #include "pp.h"
+#include "snap_internal.h"	/* ARRAY_SIZE, ... */
+
+#define PP_HISTORY		10000
+
+static int _pp_strategy = PP_STRATEGY_UPDOWN;
+static int _pp_history = PP_HISTORY;
 
 struct __lba {
 	off_t lba;
 	unsigned int nblocks;
+	unsigned long usecs;
 };
 
 struct __pp {
 	pthread_mutex_t lock;
-	int prefetch_count;
+	struct pp_funcs *f;
+	int pp_prefetch;
 	struct __lba *lba_list;	/* lba request history */
-	unsigned int lba_max;	/* maximum # of lba histrory */
+	unsigned int lba_max;	/* maximum # of lba history */
 	unsigned int lba_ridx;	/* read index */
 	unsigned int lba_widx;	/* write index */
+	unsigned int lba_num;	/* valid entries */
+	pthread_t tid;
+
+	void *put_data;
+	size_t put_nblocks;
+	int (* pp_put_offslist)(void *put_data, int *offslist, unsigned int n, size_t nblocks);
 };
 
-struct __pp pp;
+struct pp_funcs {
+	int (* pp_add_lba)(off_t lba, size_t nblocks, unsigned long usecs, int _read);
+	int (* pp_get_offslist)(int *offslist, unsigned int n, size_t nblocks);
+	void * (* pp_thread)(struct __pp *pp);
+};
 
-int pp_init(int strategy __attribute__((unused)),
-	int prefetch_count,
-	unsigned int lba_max)
-{
-	pp.lba_list = calloc(1, lba_max * sizeof(struct __lba));
-	if (!pp.lba_list)
-		return -1;
-	pp.prefetch_count = prefetch_count;
-
-	return 0;
-}
-void pp_done(void)
-{
-	if (pp.lba_list)
-		free(pp.lba_list);
-	pp.lba_list = NULL;
-}
+static struct __pp pp;
 
 /*
  * Every time a new LBA is requested, we need to be called to update
@@ -75,10 +80,44 @@ void pp_done(void)
  * @lba:       requested LBA
  * @nblocks:   how many blocks per LBA
  */
-int pp_add_lba(off_t lba __attribute__((unused)),
-	size_t nblocks __attribute__((unused)))
+static int __pp_add_lba(off_t lba  __attribute__((unused)),
+		size_t nblocks  __attribute__((unused)),
+		unsigned long usecs  __attribute__((unused)),
+		int _read __attribute__((unused)))
 {
+	pthread_mutex_lock(&pp.lock);
+
+	pp.lba_list[pp.lba_widx].lba = lba;
+	pp.lba_list[pp.lba_widx].nblocks = nblocks;
+	pp.lba_list[pp.lba_widx].usecs = usecs;
+
+	pp_trace("  [%s] %s[%4u] LBA=%ld nblocks=%i %ld usecs\n",
+		__func__, _read ? "lba_read" : "lba_write",
+		pp.lba_widx, lba, (int)nblocks, usecs);
+
+	if (pp.lba_num < pp.lba_max) {
+		pp.lba_num++;
+		pp.lba_widx = (pp.lba_widx + 1) % pp.lba_max;
+	} else {
+		pp.lba_ridx = (pp.lba_ridx + 1) % pp.lba_max;
+		pp.lba_widx = (pp.lba_widx + 1) % pp.lba_max;
+	}
+
+	pthread_mutex_unlock(&pp.lock);
 	return 0;
+}
+
+static inline void __print_offslist(int *offslist, unsigned int n)
+{
+	unsigned int i;
+	char s[128], num[32];
+
+	strcpy(s, " ");
+	for (i = 0; i < n; i++) {
+		sprintf(num, "%d ", offslist[i]);
+		strcat(s, num);
+	}
+	pp_trace("[%s] pp_offslist: [%s]\n", __func__, s); 
 }
 
 /*
@@ -86,13 +125,15 @@ int pp_add_lba(off_t lba __attribute__((unused)),
  * that the optimal prefetch sequence can be used.
  *
  * @p:         priority detector
- * @priolist:  array of lba offsets e.g. -4, -2, 2, 4
+ * @offslist:  array of lba offsets e.g. -4, -2, 2, 4
  * @n:         size of priorization list
  */
-int pp_get_offslist(int *offslist, unsigned int n, size_t nblocks)
+static int __pp_updown_offslist(int *offslist, unsigned int n, size_t nblocks)
 {
 	unsigned int i;
 	int offs;
+
+	pthread_mutex_lock(&pp.lock);
 
 	for (i = 0, offs = nblocks; i < n/2; i++, offs += nblocks)
 		offslist[i] = offs;
@@ -100,6 +141,192 @@ int pp_get_offslist(int *offslist, unsigned int n, size_t nblocks)
 	for (i = n/2, offs = -nblocks; i < n; i++, offs -= nblocks)
 		offslist[i] = offs;
 
+	pthread_mutex_unlock(&pp.lock);
+	__print_offslist(offslist, n);
 	return 0;
 }
 
+static int __pp_up_offslist(int *offslist, unsigned int n, size_t nblocks)
+{
+	unsigned int i;
+	int offs;
+
+	pthread_mutex_lock(&pp.lock);
+
+	for (i = 0, offs = nblocks; i < n; i++, offs += nblocks)
+		offslist[i] = offs;
+
+	pthread_mutex_unlock(&pp.lock);
+	__print_offslist(offslist, n);
+	return 0;
+}
+
+static int __pp_down_offslist(int *offslist, unsigned int n, size_t nblocks)
+{
+	unsigned int i;
+	int offs;
+
+	pthread_mutex_lock(&pp.lock);
+
+	for (i = 0, offs = -nblocks; i < n; i++, offs -= nblocks)
+		offslist[i] = offs;
+
+	pthread_mutex_unlock(&pp.lock);
+	__print_offslist(offslist, n);
+	return 0;
+}
+
+static void *__pp_thread(struct __pp *pp)
+{
+	pp_trace("[%s] pp.lba_num=%d pp.lba_widx=%d pp.lba_ridx=%d\n",
+		__func__, pp->lba_num, pp->lba_widx, pp->lba_ridx);
+
+	return NULL;
+}
+
+static struct pp_funcs pp_funcs[] = {
+	/* 0: PP_STRATEGY_UP */
+	{ .pp_add_lba = __pp_add_lba,
+	  .pp_get_offslist = __pp_up_offslist,
+	  .pp_thread = __pp_thread },
+	/* 1: PP_STRATEGY_DOWN */
+	{ .pp_add_lba = __pp_add_lba,
+	  .pp_get_offslist = __pp_down_offslist,
+	  .pp_thread = __pp_thread },
+	/* 2: PP_STRATEGY_UPDOWN */
+	{ .pp_add_lba = __pp_add_lba,
+	  .pp_get_offslist = __pp_updown_offslist,
+	  .pp_thread = __pp_thread },
+	/* 3: PP_STRATEGY_SMART */
+	{ .pp_add_lba = __pp_add_lba,
+	  .pp_get_offslist = __pp_updown_offslist,
+	  .pp_thread = __pp_thread },
+};
+
+int pp_add_lba(off_t lba, size_t nblocks, unsigned long usecs, int _read)
+{
+	/* pp_trace("[%s]\n", __func__); */
+
+	if (pp.f->pp_add_lba)
+		return pp.f->pp_add_lba(lba, nblocks, usecs, _read);
+	return 0;
+}
+
+int pp_get_offslist(int *offslist, unsigned int n, size_t nblocks)
+{
+	/* pp_trace("[%s]\n", __func__); */
+
+	if (pp.f->pp_get_offslist)
+		return pp.f->pp_get_offslist(offslist, n, nblocks);
+	return 0;
+}
+
+static void *pp_thread(void *arg __attribute__((unused)))
+{
+	struct __pp *pp = (struct __pp *)arg;
+
+	while (1) {
+		/* Do something useful */
+		if (pp->f->pp_thread) {
+			pthread_mutex_lock(&pp->lock);
+			pp->f->pp_thread(pp);
+			pthread_mutex_unlock(&pp->lock);
+		}
+		if (pp->pp_put_offslist)
+			pp->pp_put_offslist(pp->put_data, NULL,
+				pp->pp_prefetch, pp->put_nblocks);
+
+		sleep(1);
+		pthread_testcancel();	/* go home if requested */
+	}
+
+	return NULL;
+}
+
+/*
+ * @strategy:     Devines how the next LBAs should be prefetched
+ * @pp_prefetch:  How many entries should be prefetched
+ * @pp_history:   How many LBAs should be kept for the calculation
+ */
+int pp_init(int pp_prefetch, pp_put_offslist_t put,  size_t put_nblocks, void *put_data)
+{
+	int rc;
+
+	pthread_mutex_init(&pp.lock, NULL);
+
+	pp.lba_list = calloc(1, _pp_history * sizeof(struct __lba));
+	if (!pp.lba_list)
+		return -1;
+
+	pp.f = &pp_funcs[_pp_strategy];
+	pp.lba_ridx = 0;
+	pp.lba_widx = 0;
+	pp.lba_max = _pp_history;
+	pp.pp_prefetch = pp_prefetch;
+
+	pp.pp_put_offslist = put;
+	pp.put_nblocks = put_nblocks;
+	pp.put_data = put_data;
+
+	rc = pthread_create(&pp.tid, NULL, &pp_thread, &pp);
+	if (rc != 0)
+		goto err_out;
+
+	return 0;
+ err_out:
+	free(pp.lba_list);
+	return -1;
+}
+void pp_done(void)
+{
+	if (pp.lba_list) {
+		free(pp.lba_list);
+		pp.lba_list = NULL;
+	}
+
+	if (pp.tid != 0) {
+		pthread_cancel(pp.tid);
+		pthread_join(pp.tid, NULL);
+		pp.tid = 0;
+	}
+}
+
+static void _init(void) __attribute__((constructor));
+
+static void _init(void)
+{
+	const char *env;
+
+	env = getenv("CLBK_HISTORY");
+	if (env != NULL)
+		_pp_history = strtol(env, (char **)NULL, 0);
+	if (_pp_history <= 0)
+		_pp_history = PP_HISTORY;
+
+	env = getenv("CLBK_STRATEGY");
+	if (env != NULL) {
+		if (strcmp(env, "UP") == 0)
+			_pp_strategy = PP_STRATEGY_UP;
+		else if (strcmp(env, "DOWN") == 0)
+			_pp_strategy = PP_STRATEGY_DOWN;
+		else if (strcmp(env, "UPDOWN") == 0)
+			_pp_strategy = PP_STRATEGY_UPDOWN;
+		else if  (strcmp(env, "SMART") == 0)
+			_pp_strategy = PP_STRATEGY_SMART;
+		else if (env != NULL) {
+			_pp_strategy = strtol(env, (char **)NULL, 0);
+			if (_pp_strategy < 0 || _pp_strategy >= PP_STRATEGY_MAX)
+				_pp_strategy = PP_STRATEGY_UPDOWN;
+		}
+	}
+
+	pp_trace("[%s] CLBK_HISTORY=%d CLBD_STRATEGY=%s\n", __func__, _pp_history,
+		getenv("CLBK_STRATEGY")); 
+}
+
+static void _done(void) __attribute__((destructor));
+
+static void _done(void)
+{
+	pp_done();
+}

--- a/actions/hdl_nvme_example/sw/pp.c
+++ b/actions/hdl_nvme_example/sw/pp.c
@@ -89,12 +89,16 @@ int pp_add_lba(off_t lba __attribute__((unused)),
  * @priolist:  array of lba offsets e.g. -4, -2, 2, 4
  * @n:         size of priorization list
  */
-int pp_get_priolist(int *priolist, unsigned int n, size_t nblocks)
+int pp_get_offslist(int *offslist, unsigned int n, size_t nblocks)
 {
 	unsigned int i;
+	int offs;
 
-	for (i = 0; i < n; i++)
-		priolist[i] = (i - n/2) + nblocks * i;
+	for (i = 0, offs = nblocks; i < n/2; i++, offs += nblocks)
+		offslist[i] = offs;
+
+	for (i = n/2, offs = -nblocks; i < n; i++, offs -= nblocks)
+		offslist[i] = offs;
 
 	return 0;
 }

--- a/actions/hdl_nvme_example/sw/pp.h
+++ b/actions/hdl_nvme_example/sw/pp.h
@@ -1,0 +1,56 @@
+#ifndef __PP_H__
+#define __PP_H__
+
+/**
+ * Copyright 2017 International Business Machines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Prefetch Predictor
+ *
+ * From a given sequence of LBAs (logical block addresses), we like
+ * to predict an optimal order of LBAs to be prefetched. That should
+ * help to reduce the latency needed to load the next LBA from an
+ * NVMe device.
+ *
+ * We tried positive and negative sequences, but we wondered if a
+ * sequence based on the history of requested LBAs can be of advantage.
+ */
+
+#include <stdint.h>
+
+int pp_init(int strategy, int prefetch_count, unsigned int lba_max);
+void pp_done(void);
+
+/*
+ * Every time a new LBA is requested, we need to be called to update
+ * our list of the last lba_max LBAs. This is required to calculate
+ * the optimal priolist every once in a while, e.g. every 1 sec.
+ *
+ * @lba:       requested LBA
+ * @nblocks:   how many blocks per LBA
+ */
+int pp_add_lba(off_t lba, size_t nblocks);
+
+/*
+ * The user is asked to update the priolist in a regular fashion such
+ * that the optimal prefetch sequence can be used.
+ *
+ * @priolist:  array of lba offsets e.g. -4, -2, 2, 4
+ * @n:         size of priorization list
+ */
+int pp_get_priolist(int *priolist, unsigned int n, size_t nblocks);
+
+#endif /* __PP_H__ */

--- a/actions/hdl_nvme_example/sw/pp.h
+++ b/actions/hdl_nvme_example/sw/pp.h
@@ -31,6 +31,11 @@
 
 #include <stdint.h>
 
+#define PP_STRATEGY_POSITIVE	1
+#define PP_STRATEGY_NEGATIVE	2
+#define PP_STRATEGY_POSNEG	3 /* default */
+#define PP_STRATEGY_SMART	4
+
 int pp_init(int strategy, int prefetch_count, unsigned int lba_max);
 void pp_done(void);
 
@@ -51,6 +56,6 @@ int pp_add_lba(off_t lba, size_t nblocks);
  * @priolist:  array of lba offsets e.g. -4, -2, 2, 4
  * @n:         size of priorization list
  */
-int pp_get_priolist(int *priolist, unsigned int n, size_t nblocks);
+int pp_get_offslist(int *offslist, unsigned int n, size_t nblocks);
 
 #endif /* __PP_H__ */

--- a/actions/hdl_nvme_example/sw/pp.h
+++ b/actions/hdl_nvme_example/sw/pp.h
@@ -31,12 +31,17 @@
 
 #include <stdint.h>
 
-#define PP_STRATEGY_POSITIVE	1
-#define PP_STRATEGY_NEGATIVE	2
-#define PP_STRATEGY_POSNEG	3 /* default */
-#define PP_STRATEGY_SMART	4
+enum pp_strategy {
+	PP_STRATEGY_UP = 0,
+	PP_STRATEGY_DOWN,
+	PP_STRATEGY_UPDOWN, /* default */
+	PP_STRATEGY_SMART,
+	PP_STRATEGY_MAX,
+};
 
-int pp_init(int strategy, int prefetch_count, unsigned int lba_max);
+typedef int (* pp_put_offslist_t)(void *put_data, int *offslist, unsigned int n, size_t nblocks);
+
+int pp_init(int pp_prefetch, pp_put_offslist_t put,  size_t put_nblocks, void *put_data);
 void pp_done(void);
 
 /*
@@ -47,7 +52,7 @@ void pp_done(void);
  * @lba:       requested LBA
  * @nblocks:   how many blocks per LBA
  */
-int pp_add_lba(off_t lba, size_t nblocks);
+int pp_add_lba(off_t lba, size_t nblocks, unsigned long usecs, int _read);
 
 /*
  * The user is asked to update the priolist in a regular fashion such

--- a/actions/hdl_nvme_example/sw/snap_cblk.c
+++ b/actions/hdl_nvme_example/sw/snap_cblk.c
@@ -487,7 +487,8 @@ int main(int argc, char *argv[])
 	switch (_op) {
 	case OP_READ: {
 		fprintf(stderr, "Reading %zu times %zu bytes: %zu KiB NVMe into %s\n",
-			num_lba/lba_blocks, lba_blocks * lba_size, num_lba * lba_size / 1024,
+			num_lba/lba_blocks, lba_blocks * lba_size,
+			num_lba * lba_size / 1024,
 			fname);
 
 		if (start_lba + num_lba > lun_size) {
@@ -537,8 +538,8 @@ int main(int argc, char *argv[])
 		gettimeofday(&etime, NULL);
 #else
 		rqueue_init(&rq, buf, start_lba, lba_size, num_lba, lba_blocks);
-
 		gettimeofday(&stime, NULL);
+
 		rc = run_threads(thread_data, threads, &rq);
 		if (rc != 0) {
 			fprintf(stderr, "err: run_threads unhappy rc=%d! %s\n", rc,
@@ -560,8 +561,10 @@ int main(int argc, char *argv[])
 		mib_sec = (diff_usec == 0) ? 0.0 :
 			(double)(num_lba * lba_size) / diff_usec;
 
-		fprintf(stderr, "Reading of %lld bytes took %lld usec @ %.3f MiB/sec\n",
-			(long long)num_lba * lba_size, (long long)diff_usec, mib_sec);
+		fprintf(stderr, "Reading of %lld bytes with %d threads took %lld usec @ %.3f MiB/sec %s\n",
+			(long long)num_lba * lba_size, threads,
+			(long long)diff_usec, mib_sec,
+			random_seed ? "random ordering" : "linear ordering");
 		break;
 	}
 	case OP_WRITE: {

--- a/actions/hdl_nvme_example/sw/snap_cblk.c
+++ b/actions/hdl_nvme_example/sw/snap_cblk.c
@@ -346,7 +346,6 @@ static void *read_thread(void *data)
 				rc, strerror(errno));
 			goto err_out;
 		}
-		fprintf(stderr, "[%s] needed %ld usecs\n", __func__, diff_usec);
 
 		/* Update statistics under lock to make it consistent */
 		pthread_mutex_lock(&rq->read_lock);

--- a/actions/hdl_nvme_example/sw/snap_cblk.c
+++ b/actions/hdl_nvme_example/sw/snap_cblk.c
@@ -535,7 +535,7 @@ int main(int argc, char *argv[])
 			rc);
 		goto err_out;
 	}
-	fprintf(stderr, "NVMe device has %zu blocks of each %zu bytes; "
+	fprintf(stdout, "NVMe device has %zu blocks of each %zu bytes; "
 		"%zu MiB (MAX 0x%lx blocks) @ %u threads\n",
 		lun_size, lba_size, lun_size * lba_size / (1024 * 1024),
 		lun_size,
@@ -551,7 +551,7 @@ int main(int argc, char *argv[])
 		/* fprintf(stderr, "num_lba=%u lba_blocks=%zu lun_size=%zu\n",
 			num_lba, lba_blocks, lun_size); */
 
-		fprintf(stderr, "Reading %zu times %zu bytes: %zu KiB NVMe into %s\n",
+		fprintf(stdout, "Reading %zu times %zu bytes: %zu KiB NVMe into %s\n",
 			num_lba/lba_blocks, lba_blocks * lba_size,
 			num_lba * lba_size / 1024,
 			fname);
@@ -648,7 +648,7 @@ int main(int argc, char *argv[])
 		mib_sec = (diff_usec == 0) ? 0.0 :
 			(double)(num_lba * lba_size) / diff_usec;
 
-		fprintf(stderr, "Reading of %lld bytes with %d threads took %lld usec @ %.3f MiB/sec %s\n",
+		fprintf(stdout, "Reading of %lld bytes with %d threads took %lld usec @ %.3f MiB/sec %s\n",
 			(long long)num_lba * lba_size, threads,
 			(long long)diff_usec, mib_sec,
 			random_seed ? "random ordering" : "linear ordering");
@@ -657,7 +657,7 @@ int main(int argc, char *argv[])
 	case OP_WRITE: {
 		ssize_t len;
 
-		fprintf(stderr, "Writing NVMe from %s\n", fname);
+		fprintf(stdout, "Writing NVMe from %s\n", fname);
 		len = file_size(fname);
 		if (len <= 0)
 			goto err_out;
@@ -713,12 +713,12 @@ int main(int argc, char *argv[])
 		mib_sec = (diff_usec == 0) ? 0.0 :
 			(double)(num_lba * lba_size) / diff_usec;
 
-		fprintf(stderr, "Writing of %lld bytes took %lld usec @ %.3f MiB/sec\n",
+		fprintf(stdout, "Writing of %lld bytes took %lld usec @ %.3f MiB/sec\n",
 			(long long)num_lba * lba_size, (long long)diff_usec, mib_sec);
 		break;
 	}
 	case OP_FORMAT: {
-		fprintf(stderr, "Formatting NVMe drive %zu KiB with pattern %02x ...\n",
+		fprintf(stdout, "Formatting NVMe drive %zu KiB with pattern %02x ...\n",
 			(num_lba * lba_size) / 1024, pattern);
 
 		if (num_lba < lba_blocks) {
@@ -769,7 +769,7 @@ int main(int argc, char *argv[])
 		mib_sec = (diff_usec == 0) ? 0.0 :
 			(double)(num_lba * lba_size) / diff_usec;
 
-		fprintf(stderr, "Formatting of %lld bytes took %lld usec @ %.3f MiB/sec\n",
+		fprintf(stdout, "Formatting of %lld bytes took %lld usec @ %.3f MiB/sec\n",
 			(long long)num_lba * lba_size, (long long)diff_usec, mib_sec);
 		break;
 	default:

--- a/actions/hdl_nvme_example/sw/snap_cblk.c
+++ b/actions/hdl_nvme_example/sw/snap_cblk.c
@@ -486,6 +486,9 @@ int main(int argc, char *argv[])
 
 	switch (_op) {
 	case OP_READ: {
+		/* fprintf(stderr, "num_lba=%u lba_blocks=%zu lun_size=%zu\n",
+			num_lba, lba_blocks, lun_size); */
+
 		fprintf(stderr, "Reading %zu times %zu bytes: %zu KiB NVMe into %s\n",
 			num_lba/lba_blocks, lba_blocks * lba_size,
 			num_lba * lba_size / 1024,

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -886,7 +886,8 @@ static int check_request_timeouts(struct cblk_dev *c, struct timeval *etime,
 
 				errno = ETIME;
 				cblk_set_status(req, CBLK_ERROR);
-				sem_post(&req->wait_sem);
+				if (req->use_wait_sem)
+					sem_post(&req->wait_sem);
 			}
 		}
 	}
@@ -1575,6 +1576,8 @@ static void _done(void)
 		"    block_writes_4k:   %ld\n"
 		"  idle_wakeups:        %ld\n"
 		"  running:             %ld usec\n"
+		"  reading:             %ld usec\n"
+		"  writing:             %ld usec\n"
 		"  rbytes_total:        %lld %.3f MiB/sec\n"
 		"  wbytes_total:        %lld %.3f MiB/sec\n"
 		"  max_read_usecs:      %ld usec\n"
@@ -1597,16 +1600,18 @@ static void _done(void)
 		c->block_writes_4k,
 		c->idle_wakeups,
 		(long int)usec,
+		c->avg_read_usecs,
+		c->avg_write_usecs,
 		c->rbytes_total, usec ? (double)c->rbytes_total / usec : 0.0,
 		c->wbytes_total, usec ? (double)c->wbytes_total / usec : 0.0,
 		c->max_read_usecs,
 		c->max_write_usecs,
-		c->block_reads ? c->avg_read_usecs/c->block_reads : 0,
-		c->block_writes ? c->avg_write_usecs/c->block_writes : 0,
+		c->hw_block_reads ? c->avg_read_usecs/c->hw_block_reads : 0,
+		c->hw_block_writes ? c->avg_write_usecs/c->hw_block_writes : 0,
 		c->min_read_usecs,
 		c->min_write_usecs,
-		c->block_reads ? c->avg_hw_read_usecs/c->block_reads : 0,
-		c->block_writes ? c->avg_hw_write_usecs/c->block_writes : 0);
+		c->hw_block_reads ? c->avg_hw_read_usecs/c->hw_block_reads : 0,
+		c->hw_block_writes ? c->avg_hw_write_usecs/c->hw_block_writes : 0);
 
 	fprintf(stderr, "Cache Info\n"
 		"  entries/ways:        %d/%d per block %d KiB\n"

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -1629,7 +1629,7 @@ static void _done(void)
 
 	block_trace("[%s] exit\n", __func__);
 
-	fprintf(stderr, "Statistics\n"
+	stat_trace("Statistics\n"
 		"  prefetches:          %ld\n"
 		"  prefetch_collisions: %ld\n"
 		"  cache_hits:          %ld\n"
@@ -1679,7 +1679,7 @@ static void _done(void)
 		c->hw_block_reads ? c->avg_hw_read_usecs/c->hw_block_reads : 0,
 		c->hw_block_writes ? c->avg_hw_write_usecs/c->hw_block_writes : 0);
 
-	fprintf(stderr, "Cache Info\n"
+	cache_trace("Cache Info\n"
 		"  entries/ways:        %d/%d per block %d KiB\n"
 		"  total_size:          %d MiB\n",
 		CACHE_ENTRIES, CACHE_WAYS, __CBLK_BLOCK_SIZE / 1024,

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -675,7 +675,7 @@ static int cache_unreserve(struct cache_way *e, off_t lba)
 		dfprintf(stderr, "[%s] err: LBA=%ld/%ld not consistent!\n",
 			__func__, lba, e->lba);
 		e->status = CACHE_BLOCK_UNUSED;
-		__backtrace();
+		/* __backtrace(); */
 		pthread_mutex_unlock(&entry->way_lock);
 		return -1;
 	}
@@ -684,7 +684,7 @@ static int cache_unreserve(struct cache_way *e, off_t lba)
 			"cache from %s to UNUSED!\n",
 			__func__, e, lba, e->lba, block_status_str[e->status]);
 		e->status = CACHE_BLOCK_UNUSED;
-		__backtrace();
+		/* __backtrace(); */
 	}
 
 	pthread_mutex_unlock(&entry->way_lock);
@@ -882,7 +882,7 @@ static struct cblk_req *get_read_req(struct cblk_dev *c,
 	unsigned int j;
 	struct cblk_req *req;
 
-	while (1) {
+	while (c->status == CBLK_READY) {
 		sem_wait(&c->r_busy_sem);
 		pthread_mutex_lock(&c->dev_lock);
 
@@ -927,7 +927,7 @@ static struct cblk_req *get_write_req(struct cblk_dev *c,
 	int i, slot;
 	struct cblk_req *req;
 
-	while (1) {
+	while (c->status == CBLK_READY) {
 		sem_wait(&c->w_busy_sem);
 		pthread_mutex_lock(&c->dev_lock);
 

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -240,7 +240,7 @@ struct cblk_dev {
 	unsigned int ridx;
 	struct cblk_req req[CBLK_IDX_MAX];
 	enum cblk_status req_status;
-	int prefetch_offs[CBLK_IDX_MAX];
+	int prefetch_offs[CBLK_IDX_MAX];	/* list of LBA offsets to prefetch */
 
 	sem_t w_busy_sem;	/* wait if there is no write slot */
 	sem_t r_busy_sem;	/* wait if there is no read slot */

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -40,8 +40,8 @@
 #undef CONFIG_PRINT_STATUS	/* health checking if needed */
 
 #define CONFIG_MAX_RETRIES		5
-#define CONFIG_BUSY_TIMEOUT_SEC		10
-#define CONFIG_REQ_TIMEOUT_SEC		5
+#define CONFIG_BUSY_TIMEOUT_SEC		4
+#define CONFIG_REQ_TIMEOUT_SEC		3
 #define CONFIG_REQ_DURATION_USEC	100000 /* usec */
 
 static int cblk_reqtimeout = CONFIG_REQ_TIMEOUT_SEC;
@@ -1587,6 +1587,10 @@ static int block_read(struct cblk_dev *c, void *buf, off_t lba,
 		errno = EBADFD;
 		return -1;
 	}
+	if ((lba < 0) || (lba >= (off_t)c->nblocks)) {	/* no valid LBA */
+		errno = EFAULT;
+		return 0;
+	}
 	if (nblocks > CBLK_NBLOCKS_MAX) {
 		fprintf(stderr, "err: temp buffer too small!\n");
 		errno = EFAULT;
@@ -1724,6 +1728,10 @@ static int block_write(struct cblk_dev *c, void *buf, off_t lba,
 
 	if (c->status != CBLK_READY) {	/* device in fatal error */
 		errno = EBADFD;
+		return 0;
+	}
+	if ((lba < 0) || (lba >= (off_t)c->nblocks)) {	/* no valid LBA */
+		errno = EFAULT;
 		return 0;
 	}
 	if (nblocks > CBLK_NBLOCKS_WRITE_MAX) {

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -529,6 +529,12 @@ static inline struct cache_way *cache_reserve(off_t lba)
 			}
 			break;
 		case CACHE_BLOCK_READING:	/* do not throw this out */
+			if (e->lba == lba) {	/* entry is already in cache */
+				fprintf(stderr, "[%s] LBA=%ld is already READING!\n",
+					__func__, e->lba);
+				pthread_mutex_unlock(&entry->way_lock);
+				return NULL;	/* no entry found! */
+			}
 			break;
 		}
 	}

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -649,6 +649,11 @@ static inline int cache_unreserve(struct cache_way *e)
 	return 0;
 }
 
+/**
+ * FIXME The non-atomic cache_reserve() -> cache_write_reserved() 
+ *       sequence is not working if we allow reservations to be
+ *       changed in certain cases. This needs fixups.
+ */
 static inline int cache_write(off_t lba, const void *buf, int _used)
 {
 	struct cache_way *e;

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -49,6 +49,7 @@
 #define CONFIG_REQ_TIMEOUT_SEC		3
 #define CONFIG_REQ_DURATION_USEC	100000 /* usec */
 
+static int cblk_maxretries = CONFIG_MAX_RETRIES;
 static int cblk_reqtimeout = CONFIG_REQ_TIMEOUT_SEC;
 static int cblk_busytimeout = CONFIG_BUSY_TIMEOUT_SEC;
 
@@ -1194,7 +1195,7 @@ static int check_req_timeouts(struct cblk_dev *c, struct timeval *etime,
 				__func__, i, cblk_status_str[req->status],
 				timeout_sec, diff_sec, req->lba);
 
-			if (req->tries >= CONFIG_MAX_RETRIES) {
+			if (req->tries >= cblk_maxretries) {
 				uint32_t errbits;
 
 				errno = ETIME;
@@ -1949,6 +1950,10 @@ static void _init(void)
 {
 	const char *env;
 
+	env = getenv("CBLK_MAXRETRIES");
+	if (env != NULL)
+		cblk_maxretries = strtol(env, (char **)NULL, 0);
+
 	env = getenv("CBLK_REQTIMEOUT");
 	if (env != NULL)
 		cblk_reqtimeout = strtol(env, (char **)NULL, 0);
@@ -1979,9 +1984,9 @@ static void _init(void)
 	if (env != NULL)
 		cblk_prefetch_threshold = strtol(env, (char **)NULL, 0);
 
-	block_trace("[%s] CBLK_REQTIMEOUT=%d CBLK_PREFETCH=%d "
+	block_trace("[%s] CBLK_MAXRETRIES=%d CBLK_REQTIMEOUT=%d CBLK_PREFETCH=%d "
 		"CBLK_PREFETCH_THRESHOLD=%d CBLK_CACHING=%d\n",
-		__func__, cblk_reqtimeout, cblk_prefetch,
+		    __func__, cblk_maxretries, cblk_reqtimeout, cblk_prefetch,
 		cblk_prefetch_threshold, cblk_caching);
 }
 

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -1645,10 +1645,10 @@ static int block_read(struct cblk_dev *c, void *buf, off_t lba,
 	if (cblk_prefetch) {
 		unsigned int k;
 
-		for (k = 0; (k < (unsigned int)cblk_prefetch) &&
-			(reads_in_flight(c) < CBLK_PREFETCH_THRESHOLD); k++)
-			__prefetch_read_start(c, lba, nblocks,
-				1 + k, mem_size);
+		for (k = 0; (k < (unsigned int)cblk_prefetch); k++)
+			if (reads_in_flight(c) < CBLK_PREFETCH_THRESHOLD)
+				__prefetch_read_start(c, lba, nblocks,
+					1 + k, mem_size);
 	}
 
 	while (req->status == CBLK_READING) {

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -40,7 +40,7 @@
 #undef CONFIG_PRINT_STATUS	/* health checking if needed */
 
 #define CONFIG_MAX_RETRIES		5
-#define CONFIG_BUSY_TIMEOUT_SEC		4
+#define CONFIG_BUSY_TIMEOUT_SEC		5
 #define CONFIG_REQ_TIMEOUT_SEC		3
 #define CONFIG_REQ_DURATION_USEC	100000 /* usec */
 

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -34,15 +34,15 @@
 #include "snap_hls_if.h"
 #include "capiblock.h"
 
-#undef CONFIG_WAIT_FOR_IRQ	/* Not fully working */
+#undef CONFIG_WAIT_FOR_IRQ	/* Not working */
 #undef CONFIG_PRINT_STATUS	/* health checking if needed */
 #undef CONFIG_FIFO_SCHEDULING	/* only root */
 #undef CONFIG_PIN_COMPLETION_THREAD	/* try to pin completion thread */
 #define CONFIG_SOFTWARE_TIME	/* measure hardware */
 #define CONFIG_SLEEP_WHEN_IDLE	/* Sleep when there is no work to be done */
 
-#define CONFIG_REQUEST_TIMEOUT 5
-#define CONFIG_REQUEST_DURATION 100 /* usec */
+#define CONFIG_REQUEST_TIMEOUT	5
+#define CONFIG_REQUEST_DURATION	1000 /* usec */
 
 static int cblk_reqtimeout = CONFIG_REQUEST_TIMEOUT;
 static int cblk_prefetch = 0;
@@ -1086,8 +1086,7 @@ chunk_id_t cblk_open(const char *path,
 	unsigned int i, j;
 	int timeout = ACTION_WAIT_TIME;
 	unsigned long have_nvme = 0;
-	snap_action_flag_t attach_flags =
-		(SNAP_ACTION_DONE_IRQ | SNAP_ATTACH_IRQ);
+	snap_action_flag_t attach_flags = 0;
 	struct cblk_dev *c = &chunk;
 
 	block_trace("[%s] opening (%s) CBLK_REQTIMEOUT=%d CBLK_PREFETCH=%d\n",
@@ -1095,6 +1094,9 @@ chunk_id_t cblk_open(const char *path,
 
 	pthread_mutex_lock(&c->dev_lock);
 
+#ifdef CONFIG_WAIT_FOR_IRQ
+	attach_flags |= (SNAP_ACTION_DONE_IRQ | SNAP_ATTACH_IRQ);
+#endif
 	if (flags & CBLK_OPN_VIRT_LUN) {
 		fprintf(stderr, "err: Virtual luns not supported in capi stub\n");
 		goto out_err0;

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -754,7 +754,7 @@ static int __cblk_read(struct cblk_dev *c, uint32_t addr, uint32_t *data)
 #ifdef CONFIG_MMIO32_NOHWSYNC
 	rc = snap_mmio_read32_nohwsync(c->card, (uint64_t)addr, data);
 #else
-	rc = snap_mmio_read32_nohwsync(c->card, (uint64_t)addr, data);
+	rc = snap_mmio_read32(c->card, (uint64_t)addr, data);
 #endif
 	if (0 != rc)
 		fprintf(stderr, "err: Read MMIO 32 Err %d\n", rc);

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -159,7 +159,6 @@ static inline unsigned long atomic_inc(atomic_t *a)
 #define CBLK_NBLOCKS_MAX	32	/* 128 KiB / 4KiB */
 #define CBLK_NBLOCKS_WRITE_MAX	2	/* writing is just 1 or 2 blocks */
 
-#define CBLK_PREFETCH_BLOCKS	4
 #define CBLK_PREFETCH_THRESHOLD	8	/* only prefetch if reads_in_flight is small than the threshold */
 
 enum cblk_status {
@@ -1409,10 +1408,10 @@ static int block_read(struct cblk_dev *c, void *buf, off_t lba,
 	if (cblk_prefetch) {
 		unsigned int k;
 
-		for (k = 0; (k < CBLK_PREFETCH_BLOCKS) &&
+		for (k = 0; (k < (unsigned int)cblk_prefetch) &&
 			(reads_in_flight(c) < CBLK_PREFETCH_THRESHOLD); k++)
 			__prefetch_read_start(c, lba, nblocks,
-				cblk_prefetch + k, mem_size);
+				1 + k, mem_size);
 	}
 
 	while (req->status == CBLK_READING) {

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -1428,7 +1428,7 @@ static int __cache_read_timeout(struct cblk_dev *c __attribute__((unused)),
 			unsigned int timeout_usec)
 {
 	int rc;
-	uint32_t usecs = 0;
+	unsigned long usecs = 0;
 	struct timeval s, e;
 
 	gettimeofday(&s, NULL);
@@ -1446,7 +1446,7 @@ static int __cache_read_timeout(struct cblk_dev *c __attribute__((unused)),
 		}
 
 		if (rc == 0) {		/* Success */
-			block_trace("    [%s] got LBA=%ld after %d usecs\n",
+			block_trace("    [%s] got LBA=%ld after %ld usecs\n",
 				__func__, lba, usecs);
 			return rc;
 		}
@@ -1454,6 +1454,9 @@ static int __cache_read_timeout(struct cblk_dev *c __attribute__((unused)),
 		if (rc < 0)		/* Not in cache, not requested */
 			return rc;
 	}
+
+	fprintf(stderr, "[%s] Block did not arrive in time %ld usecs\n",
+		__func__, usecs);
 	return -1;		/* Timeout */
 }
 

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -1593,6 +1593,8 @@ static int block_read(struct cblk_dev *c, void *buf, off_t lba,
 		return -1;
 	}
 	if ((lba < 0) || (lba >= (off_t)c->nblocks)) {	/* no valid LBA */
+		fprintf(stderr, "[%s] err: LBA=%ld out of range (max=%ld)!\n",
+			__func__, lba, c->nblocks);
 		errno = EFAULT;
 		return 0;
 	}
@@ -1736,6 +1738,8 @@ static int block_write(struct cblk_dev *c, void *buf, off_t lba,
 		return 0;
 	}
 	if ((lba < 0) || (lba >= (off_t)c->nblocks)) {	/* no valid LBA */
+		fprintf(stderr, "[%s] err: LBA=%ld out of range (max=%ld)!\n",
+			__func__, lba, c->nblocks);
 		errno = EFAULT;
 		return 0;
 	}

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -38,6 +38,7 @@
 
 #undef CONFIG_WAIT_FOR_IRQ	/* Not working */
 #undef CONFIG_PRINT_STATUS	/* health checking if needed */
+#undef CONFIG_MMIO32_NOHWSYNC	/* Do not use hwsync behind lwz */
 
 #define CONFIG_MAX_RETRIES		5
 #define CONFIG_BUSY_TIMEOUT_SEC		5
@@ -750,7 +751,11 @@ static int __cblk_read(struct cblk_dev *c, uint32_t addr, uint32_t *data)
 {
 	int rc;
 
-	rc = snap_mmio_read32(c->card, (uint64_t)addr, data);
+#ifdef CONFIG_MMIO32_NOHWSYNC
+	rc = snap_mmio_read32_nohwsync(c->card, (uint64_t)addr, data);
+#else
+	rc = snap_mmio_read32_nohwsync(c->card, (uint64_t)addr, data);
+#endif
 	if (0 != rc)
 		fprintf(stderr, "err: Read MMIO 32 Err %d\n", rc);
 

--- a/actions/hdl_nvme_example/tests/lbalog_analysis.py
+++ b/actions/hdl_nvme_example/tests/lbalog_analysis.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+import re
+
+def main():
+	seqs = []
+	with open("run_threads1_prefetch0_lbas.log", "r") as ins:
+		lba_last = 0
+		last_seq = 0
+		for line in ins:
+			m = re.search(r"LBA=(\d+)", line)
+			if not m:
+				continue
+			lba = int(m.group(1))
+			if lba == lba_last + 2:
+				#print(">>> " + str(lba))
+				last_seq += 1
+			elif lba == lba_last - 2:
+				#print("<<< " + str(lba))
+				last_seq -= 1
+			else:
+				#print("    " + str(lba))
+				seqs.append(last_seq)
+				last_seq = 0
+			lba_last = lba
+
+	max_pos = max(seqs)
+	min_neg = min(seqs)
+
+	print("Largest positive sequence: " + str(max_pos))
+	print("Largest negative sequence: " + str(min_neg))
+
+	# define array of accumulated sizes
+	count_seqs = [0] * (max_pos + 1 + abs(min_neg));
+	for e in seqs:
+		count_seqs[abs(min_neg) + e] += 1
+
+	i = min_neg
+	for e in count_seqs:
+		print("[" + str(i) + "] " + str(e))
+		i += 1
+
+if __name__ == "__main__":
+	main()

--- a/actions/hdl_nvme_example/tests/lbalog_analysis.py
+++ b/actions/hdl_nvme_example/tests/lbalog_analysis.py
@@ -1,9 +1,27 @@
 #!/usr/bin/python
-import re
 
-def main():
+#
+# Copyright 2017 International Business Machines
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import re
+import getopt, sys
+
+def analyze_file(fname):
 	seqs = []
-	with open("run_threads1_prefetch0_lbas.log", "r") as ins:
+	with open(fname, "r") as ins:
 		lba_last = 0
 		last_seq = 0
 		for line in ins:
@@ -38,6 +56,32 @@ def main():
 	for e in count_seqs:
 		print("[" + str(i) + "] " + str(e))
 		i += 1
+
+def usage():
+	print("lbalog_analysis.py [-help] -i filename.log")
+
+def main():
+	try:
+		opts, args = getopt.getopt(sys.argv[1:], "hi:", ["help", "input="])
+	except getopt.GetoptError as err:
+        # print help information and exit:
+		print str(err)
+		usage()
+		sys.exit(2)
+
+	# fname = None
+	fname = "run_threads1_prefetch0_lbas.log"
+
+	for o, a in opts:
+		if o in ("-h", "--help"):
+			usage()
+			sys.exit()
+		elif o in ("-i", "--input"):
+			fname = a
+		else:
+			assert False, "unhandled option"
+
+	analyze_file(fname)
 
 if __name__ == "__main__":
 	main()

--- a/actions/hdl_nvme_example/tests/snap_init.sh
+++ b/actions/hdl_nvme_example/tests/snap_init.sh
@@ -22,6 +22,7 @@ reset=0
 threads=1
 nblocks=2
 prefetch=0
+random_seed=0
 options="-n 0x40000"
 
 TEST=NONE
@@ -43,6 +44,7 @@ function usage() {
 	echo "    [-b <nblocks>]    number of blocks per transfer"
 	echo "    [-t <threads>]    threads to be used"
 	echo "    [-p <prefetch>]   0/1 disable/enable prefetching"
+	echo "    [-R <seed>]       random seed, if not 0, random read odering"
 	echo "    [-T <testcase>]   testcase e.g. CBLK"
 	echo
 	echo "  Perform SNAP card initialization and action_type "
@@ -69,7 +71,7 @@ function reset_card() {
 	fi
 }
 
-while getopts ":A:b:C:T:t:n:p:rVvh" opt; do
+while getopts ":A:b:C:T:t:R:n:p:rVvh" opt; do
 	case ${opt} in
 	C)
 		card=${OPTARG};
@@ -93,6 +95,9 @@ while getopts ":A:b:C:T:t:n:p:rVvh" opt; do
 		;;
 	n)
 		options="-n ${OPTARG}"
+		;;
+	R)
+		random_seed=${OPTARG}
 		;;
 	p)
 		prefetch=${OPTARG}
@@ -138,7 +143,8 @@ if [ "${TEST}" == "READ_BENCHMARK" ]; then
 		for t in 1 4 8 12 ; do
 			echo "THREADS: $t" ;
 			CBLK_PREFETCH=$p SNAP_TRACE=0x0 \
-			snap_cblk -C0 ${options} -b${nblocks} -s0 -t${t} \
+			snap_cblk -C0 ${options} -b${nblocks} \
+				-R${random_seed} -s0 -t${t} \
 				--read block0.bin ;
 			echo
 		done

--- a/actions/hdl_nvme_example/tests/snap_init.sh
+++ b/actions/hdl_nvme_example/tests/snap_init.sh
@@ -139,7 +139,7 @@ snap_nvme_init -C${card} -d0 -d1 -v
 if [ "${TEST}" == "READ_BENCHMARK" ]; then
 	echo "SNAP NVME READ BENCHMARK"
 	for p in 0 1 ; do
-		for t in 1 2 4 6 8 10 12 14 16 32 64 ; do
+		for t in 1 2 4 6 8 10 12 14 15 16 20 24 28 32 64 ; do
 			echo "PREFETCH: $p ; THREADS: $t ; NBLOCKS=${nblocks}" ;
 			CBLK_PREFETCH=$p SNAP_TRACE=0x0 \
 			snap_cblk -C0 ${options} -b${nblocks} \

--- a/actions/hdl_nvme_example/tests/snap_init.sh
+++ b/actions/hdl_nvme_example/tests/snap_init.sh
@@ -154,17 +154,24 @@ if [ "${TEST}" == "READ_BENCHMARK" ]; then
 	done
 fi
 
+#
+# System p specific performance counter registers. Try this if you do
+# not know what it means.
+#
+# perf stat -e "{r100F8,r2D01A,r30004,r4E010},{r100F8,r2D01E,r30004,r4D01C},{r100F8,r2D01C,r30004,r4D01A},{r100F8,r2E010,r30004,r4D01E},{r100F8,r2001A,r30028,r4000A},{r1001C,r2D018,r30036,r4D018},{r100F8,r2D012,r30028,r4000A},{r1001C,r2D016,r30038,r4D016},{r100F8,r2D014,r30026,r4D012},{r1001C,r2D010,r30038,r4D010},{r100F8,r2C010,r30004,r4000A},{r1001C,r2C012,r30004,r4C01A},{r100F8,r2C016,r30004,r4C016},{r1001C,r2C01C,r30004,r4C01A},{r100F8,r2C018,r30004,r4C018},{r10036,r2C01A,r30036,r4C010},{r1001C,r2E01E,r30028,r4C014},{r1001C,r2001A,r30038,r4C012},{r1001C,r2C014,r30026,r4D014},{r1001C,r2C010,r30038,r4C01C}" <command>
+#
 if [ "${TEST}" == "PERF" ]; then
 	echo "SNAP NVME PERF BENCHMARK"
-	for p in 0 1 ; do
+	for p in 0 4 ; do
 		for t in 1 8 16 32 ; do
 			perf_log="snap_nvme_prefetch_${p}_threads_${t}.log"
 
 			echo "PREFETCH: $p ; THREADS: $t ; NBLOCKS=${nblocks}" ;
-			CBLK_PREFETCH=$p \
-			perf record snap_cblk -C0 ${options} -b${nblocks} \
-				-R${random_seed} -s0 -t${t} \
-				--read /dev/null ;
+			sudo -E -- perf record -a -g -- \
+				CBLK_PREFETCH=$p \
+				snap_cblk -C0 ${options} -b${nblocks} \
+					-R${random_seed} -s0 -t${t} \
+					--read /dev/null ;
 			if [ $? -ne 0 ]; then
 				printf "${bold}ERROR:${normal} bad exit code!\n" >&2
 				exit 1

--- a/actions/hdl_nvme_example/tests/snap_init.sh
+++ b/actions/hdl_nvme_example/tests/snap_init.sh
@@ -138,8 +138,8 @@ snap_nvme_init -C${card} -d0 -d1 -v
 
 if [ "${TEST}" == "READ_BENCHMARK" ]; then
 	echo "SNAP NVME READ BENCHMARK"
-	for p in 0 2 4 ; do
-		for t in 1 4 8 10 16 24 32 64 ; do
+	for p in 0 4 ; do
+		for t in 1 4 8 10 14 16 24 32 64 ; do
 			echo "PREFETCH: $p ; THREADS: $t ; NBLOCKS=${nblocks}" ;
 			(time CBLK_PREFETCH=$p \
 			snap_cblk -C0 ${options} -b${nblocks} \

--- a/actions/hdl_nvme_example/tests/snap_init.sh
+++ b/actions/hdl_nvme_example/tests/snap_init.sh
@@ -141,7 +141,7 @@ if [ "${TEST}" == "READ_BENCHMARK" ]; then
 	for p in 0 4 ; do
 		for t in 1 4 8 10 16 24 32 64 ; do
 			echo "PREFETCH: $p ; THREADS: $t ; NBLOCKS=${nblocks}" ;
-			(time CBLK_PREFETCH=$p SNAP_TRACE=0x0 \
+			(time CBLK_PREFETCH=$p \
 			snap_cblk -C0 ${options} -b${nblocks} \
 				-R${random_seed} -s0 -t${t} \
 				--read /dev/null );
@@ -157,7 +157,7 @@ if [ "${TEST}" == "PERF" ]; then
 			perf_log="snap_nvme_prefetch_${p}_threads_${t}.log"
 
 			echo "PREFETCH: $p ; THREADS: $t ; NBLOCKS=${nblocks}" ;
-			CBLK_PREFETCH=$p SNAP_TRACE=0x0 \
+			CBLK_PREFETCH=$p \
 			perf record snap_cblk -C0 ${options} -b${nblocks} \
 				-R${random_seed} -s0 -t${t} \
 				--read /dev/null ;

--- a/actions/hdl_nvme_example/tests/snap_init.sh
+++ b/actions/hdl_nvme_example/tests/snap_init.sh
@@ -139,12 +139,12 @@ snap_nvme_init -C${card} -d0 -d1 -v
 if [ "${TEST}" == "READ_BENCHMARK" ]; then
 	echo "SNAP NVME READ BENCHMARK"
 	for p in 0 4 ; do
-		for t in 1 4 6 8 10 12 16 24 32 64 ; do
+		for t in 1 4 8 10 16 24 32 64 ; do
 			echo "PREFETCH: $p ; THREADS: $t ; NBLOCKS=${nblocks}" ;
-			CBLK_PREFETCH=$p SNAP_TRACE=0x0 \
+			(time CBLK_PREFETCH=$p SNAP_TRACE=0x0 \
 			snap_cblk -C0 ${options} -b${nblocks} \
 				-R${random_seed} -s0 -t${t} \
-				--read /dev/null ;
+				--read /dev/null );
 			echo
 		done
 	done

--- a/actions/hdl_nvme_example/tests/snap_init.sh
+++ b/actions/hdl_nvme_example/tests/snap_init.sh
@@ -144,18 +144,20 @@ snap_nvme_init -C${card} -d0 -d1 -v
 
 if [ "${TEST}" == "READ_BENCHMARK" ]; then
 	echo "SNAP NVME READ BENCHMARK"
-	for p in 0 2 4 ; do
-		for t in 1 2 4 8 10 14 16 32 ; do
-			echo "PREFETCH: $p ; THREADS: $t ; NBLOCKS=${nblocks}" ;
-			(time CBLK_PREFETCH=$p \
-			snap_cblk -C0 ${options} -b${nblocks} \
-				-R${random_seed} -s0 -t${t} \
-				--read /dev/null );
-			if [ $? -ne 0 ]; then
-				printf "${bold}ERROR:${normal} bad exit code!\n" >&2
-				exit 1
-			fi
-			echo
+	for s in UP DOWN UPDOWN ; do
+		for p in 0 1 4 8 ; do
+			for t in 1 2 4 8 10 14 16 32 ; do
+				echo "PREFETCH: $p ; THREADS: $t ; NBLOCKS=${nblocks} ; STRATEGY=${s}" ;
+				(time CBLK_PREFETCH=$p CBLK_STRATEGY=${s} \
+				snap_cblk -C0 ${options} -b${nblocks} \
+					-R${random_seed} -s0 -t${t} \
+					--read /dev/null );
+				if [ $? -ne 0 ]; then
+					printf "${bold}ERROR:${normal} bad exit code!\n" >&2
+					exit 1
+				fi
+				echo
+			done
 		done
 	done
 fi

--- a/actions/hdl_nvme_example/tests/snap_init.sh
+++ b/actions/hdl_nvme_example/tests/snap_init.sh
@@ -140,12 +140,12 @@ if [ "${TEST}" == "READ_BENCHMARK" ]; then
 	echo "SNAP NVME READ BENCHMARK"
 	for p in 0 1 ; do
 		echo "PREFETCH: $p";
-		for t in 1 4 8 12 ; do
+		for t in 1 2 4 6 8 10 12 14 16 32 64 ; do
 			echo "THREADS: $t" ;
 			CBLK_PREFETCH=$p SNAP_TRACE=0x0 \
 			snap_cblk -C0 ${options} -b${nblocks} \
 				-R${random_seed} -s0 -t${t} \
-				--read block0.bin ;
+				--read /dev/null ;
 			echo
 		done
 	done

--- a/actions/hdl_nvme_example/tests/snap_init.sh
+++ b/actions/hdl_nvme_example/tests/snap_init.sh
@@ -138,8 +138,8 @@ snap_nvme_init -C${card} -d0 -d1 -v
 
 if [ "${TEST}" == "READ_BENCHMARK" ]; then
 	echo "SNAP NVME READ BENCHMARK"
-	for p in 0 4 ; do
-		for t in 1 4 8 10 14 16 24 32 64 ; do
+	for p in 0 2 4 ; do
+		for t in 1 2 4 8 10 14 16 32 ; do
 			echo "PREFETCH: $p ; THREADS: $t ; NBLOCKS=${nblocks}" ;
 			(time CBLK_PREFETCH=$p \
 			snap_cblk -C0 ${options} -b${nblocks} \

--- a/actions/hdl_nvme_example/tests/snap_init.sh
+++ b/actions/hdl_nvme_example/tests/snap_init.sh
@@ -139,9 +139,8 @@ snap_nvme_init -C${card} -d0 -d1 -v
 if [ "${TEST}" == "READ_BENCHMARK" ]; then
 	echo "SNAP NVME READ BENCHMARK"
 	for p in 0 1 ; do
-		echo "PREFETCH: $p";
 		for t in 1 2 4 6 8 10 12 14 16 32 64 ; do
-			echo "THREADS: $t" ;
+			echo "PREFETCH: $p ; THREADS: $t ; NBLOCKS=${nblocks}" ;
 			CBLK_PREFETCH=$p SNAP_TRACE=0x0 \
 			snap_cblk -C0 ${options} -b${nblocks} \
 				-R${random_seed} -s0 -t${t} \

--- a/actions/hdl_nvme_example/tests/snap_init.sh
+++ b/actions/hdl_nvme_example/tests/snap_init.sh
@@ -138,7 +138,7 @@ snap_nvme_init -C${card} -d0 -d1 -v
 
 if [ "${TEST}" == "READ_BENCHMARK" ]; then
 	echo "SNAP NVME READ BENCHMARK"
-	for p in 0 4 ; do
+	for p in 0 2 4 ; do
 		for t in 1 4 8 10 16 24 32 64 ; do
 			echo "PREFETCH: $p ; THREADS: $t ; NBLOCKS=${nblocks}" ;
 			(time CBLK_PREFETCH=$p \

--- a/actions/hdl_nvme_example/tests/snap_init.sh
+++ b/actions/hdl_nvme_example/tests/snap_init.sh
@@ -145,6 +145,10 @@ if [ "${TEST}" == "READ_BENCHMARK" ]; then
 			snap_cblk -C0 ${options} -b${nblocks} \
 				-R${random_seed} -s0 -t${t} \
 				--read /dev/null );
+			if [ $? -ne 0 ]; then
+				printf "${bold}ERROR:${normal} bad exit code!\n" >&2
+				exit 1
+			fi
 			echo
 		done
 	done
@@ -161,6 +165,11 @@ if [ "${TEST}" == "PERF" ]; then
 			perf record snap_cblk -C0 ${options} -b${nblocks} \
 				-R${random_seed} -s0 -t${t} \
 				--read /dev/null ;
+			if [ $? -ne 0 ]; then
+				printf "${bold}ERROR:${normal} bad exit code!\n" >&2
+				exit 1
+			fi
+
 			echo
 			echo -n "Generating perf output ${perf_log} ... "
 			sudo perf report -f > $perf_log

--- a/actions/hdl_nvme_example/tests/snap_init.sh
+++ b/actions/hdl_nvme_example/tests/snap_init.sh
@@ -43,6 +43,7 @@ function usage() {
 	echo "    [-n <lbas>]       number of lbas to try, e.g. 0x40000 for 1 GiB"
 	echo "    [-b <nblocks>]    number of blocks per transfer"
 	echo "    [-t <threads>]    threads to be used"
+	echo "    [-H <threads>]    hardware threads per CPU to be used (see ppc64_cpu)"
 	echo "    [-p <prefetch>]   0/1 disable/enable prefetching"
 	echo "    [-R <seed>]       random seed, if not 0, random read odering"
 	echo "    [-T <testcase>]   testcase e.g. CBLK, READ_BENCHMARK, PERF, ..."
@@ -71,7 +72,7 @@ function reset_card() {
 	fi
 }
 
-while getopts ":A:b:C:T:t:R:n:p:rVvh" opt; do
+while getopts ":H:A:b:C:T:t:R:n:p:rVvh" opt; do
 	case ${opt} in
 	C)
 		card=${OPTARG};
@@ -92,6 +93,11 @@ while getopts ":A:b:C:T:t:R:n:p:rVvh" opt; do
 		;;
 	t)
 		threads=${OPTARG}
+		;;
+	H)
+		hw_threads=${OPTARG}
+		sudo ppc64_cpu --smt=${hw_threads}
+		ppc64_cpu --smt
 		;;
 	n)
 		options="-n ${OPTARG}"

--- a/actions/hdl_nvme_example/tests/test_0x10140001.sh
+++ b/actions/hdl_nvme_example/tests/test_0x10140001.sh
@@ -23,9 +23,9 @@ threads=1
 nblocks=2
 prefetch=0
 random_seed=0
-duration="NORMAL"
+duration="NONE"
 options="-n 0x40000"
-TEST="READ_BENCHMARK"
+TEST="NONE"
 
 # output formatting
 bold=$(tput bold)
@@ -102,6 +102,7 @@ while getopts ":H:A:b:C:d:T:t:R:n:p:rVvh" opt; do
 		;;
 	d)
 		duration=${OPTARG}
+		TEST="READ_BENCHMARK"
 		;;
 	n)
 		options="-n ${OPTARG}"

--- a/actions/software.mk
+++ b/actions/software.mk
@@ -33,10 +33,13 @@ libs += $(SNAP_ROOT)/software/lib/libsnap.a
 
 # Link statically for PSLSE simulation and dynamically for real version
 ifdef BUILD_SIMCODE
-libs += $(PSLSE_ROOT)/libcxl/libcxl.a
+# libs += $(PSLSE_ROOT)/libcxl/libcxl.a
 CFLAGS += -D_SIM_
+LDFLAGS += -L$(PSLSE_ROOT)/libcxl
+LDLIBS += -lcxl
 else
-# FIXME If we link against libsnap.so we should have this dependency covered
+# FIXME If we link against libsnap.so we should have this dependency covered.
+#      No -L<path_to_libcxl> required here, since it should be in the distro.
 LDLIBS += -lcxl
 endif
 

--- a/actions/software.mk
+++ b/actions/software.mk
@@ -29,7 +29,7 @@ LDFLAGS += -L$(SNAP_ROOT)/software/lib
 LDLIBS += -lsnap -lpthread
 
 DESTDIR ?= /usr
-libs += $(SNAP_ROOT)/software/lib/libsnap.a
+# libs += $(SNAP_ROOT)/software/lib/libsnap.a
 
 # Link statically for PSLSE simulation and dynamically for real version
 ifdef BUILD_SIMCODE

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -22,6 +22,7 @@
 ## This Makefile is contained in the hardware directory.
 ## So, the root directory is one level above.
 ##
+SHELL=/bin/bash
 PLATFORM ?= $(shell uname -i)
 
 export SNAP_ROOT=$(abspath ..)

--- a/hardware/sim/run_sim
+++ b/hardware/sim/run_sim
@@ -196,10 +196,9 @@
  fi
 
  if [ "$PARM_FILE" != "" ];then cp ${SIMBASE}/${PARM_FILE} pslse.parms;fi       # overwrite with specified parms file
+ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PSLSE_ROOT/afu_driver/src:$PSLSE_ROOT/libcxl    # to find libvpi.so and libcxl.so
  if [[ "$NVME_USED" == "TRUE" && -n "$DENALI" ]]; then
-   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PSLSE_ROOT/afu_driver/src:$DENALI/verilog            # to find libvpi.so and libdenpli.so
- else
-   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PSLSE_ROOT/afu_driver/src                            # to find libvpi.so
+   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DENALI/verilog                                # to find libvpi.so and libdenpli.so
  fi
  if [ "$SIMDIR" == "ies" ];then
 #  if [ "$SIM_INIT" == "" ];then SIM_INIT='-ncinitialize x';fi                  # default init value for ncsim

--- a/hardware/sim/run_sim
+++ b/hardware/sim/run_sim
@@ -197,9 +197,9 @@
 
  if [ "$PARM_FILE" != "" ];then cp ${SIMBASE}/${PARM_FILE} pslse.parms;fi       # overwrite with specified parms file
  if [[ "$NVME_USED" == "TRUE" && -n "$DENALI" ]]; then
-   export LD_LIBRARY_PATH=$PSLSE_ROOT/afu_driver/src:$DENALI/verilog            # to find libvpi.so and libdenpli.so
+   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PSLSE_ROOT/afu_driver/src:$DENALI/verilog            # to find libvpi.so and libdenpli.so
  else
-   export LD_LIBRARY_PATH=$PSLSE_ROOT/afu_driver/src                            # to find libvpi.so
+   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PSLSE_ROOT/afu_driver/src                            # to find libvpi.so
  fi
  if [ "$SIMDIR" == "ies" ];then
 #  if [ "$SIM_INIT" == "" ];then SIM_INIT='-ncinitialize x';fi                  # default init value for ncsim

--- a/software/include/libsnap.h
+++ b/software/include/libsnap.h
@@ -257,6 +257,9 @@ int snap_mmio_write32(struct snap_card *card, uint64_t offset,
 int snap_mmio_read32(struct snap_card *card, uint64_t offset,
 			uint32_t *data);
 
+int snap_mmio_read32_nohwsync(struct snap_card *card,
+		uint64_t offset, uint32_t *data);
+
 int snap_mmio_write64(struct snap_card *card, uint64_t offset,
 			uint64_t data);
 int snap_mmio_read64(struct snap_card *card, uint64_t offset,

--- a/software/include/snap_internal.h
+++ b/software/include/snap_internal.h
@@ -92,6 +92,7 @@ static inline long long __get_usec(void)
 int action_trace_enabled(void);
 int block_trace_enabled(void);
 int cache_trace_enabled(void);
+int stat_trace_enabled(void);
 
 #define act_trace(fmt, ...) do {					\
 		if (action_trace_enabled())				\
@@ -109,6 +110,14 @@ int cache_trace_enabled(void);
 #define cache_trace(fmt, ...) do {                                     \
 		if (cache_trace_enabled()) {                           \
 			fprintf(stderr, "C %08x.%08x %-16lld " fmt,    \
+				getpid(), __gettid(), __get_usec(),    \
+			## __VA_ARGS__);                               \
+		}                                                      \
+	} while (0)
+
+#define stat_trace(fmt, ...) do {                                      \
+		if (stat_trace_enabled()) {                            \
+			fprintf(stderr, "S %08x.%08x %-16lld " fmt,    \
 				getpid(), __gettid(), __get_usec(),    \
 			## __VA_ARGS__);                               \
 		}                                                      \

--- a/software/include/snap_internal.h
+++ b/software/include/snap_internal.h
@@ -93,6 +93,7 @@ int action_trace_enabled(void);
 int block_trace_enabled(void);
 int cache_trace_enabled(void);
 int stat_trace_enabled(void);
+int pp_trace_enabled(void);
 
 #define act_trace(fmt, ...) do {					\
 		if (action_trace_enabled())				\
@@ -122,6 +123,15 @@ int stat_trace_enabled(void);
 			## __VA_ARGS__);                               \
 		}                                                      \
 	} while (0)
+
+#define pp_trace(fmt, ...) do {                                        \
+		if (pp_trace_enabled()) {                              \
+			fprintf(stderr, "P %08x.%08x %-16lld " fmt,    \
+				getpid(), __gettid(), __get_usec(),    \
+			## __VA_ARGS__);                               \
+		}                                                      \
+	} while (0)
+
 /**
  * Register a software version of the FPGA action to enable us
  * simulating high-level behavior of the same and allowing us to

--- a/software/lib/Makefile
+++ b/software/lib/Makefile
@@ -27,6 +27,7 @@ LDLIBS += -lcxl -lpthread
 #endif
 
 ifdef BUILD_SIMCODE
+CFLAGS += -D_SIM_
 LDFLAGS += -L$(PSLSE_ROOT)/libcxl
 endif
 

--- a/software/lib/Makefile
+++ b/software/lib/Makefile
@@ -19,11 +19,15 @@ include ../config.mk
 libversion = $(VERSION)
 
 CFLAGS += -fPIC -fno-strict-aliasing
-LDLIBS += -lpthread
+LDLIBS += -lcxl -lpthread
 
 # Link statically for PSLSE simulation and dynamically for real version
-ifndef BUILD_SIMCODE
-LDLIBS += -lcxl
+#ifndef BUILD_SIMCODE
+#LDLIBS += -lcxl
+#endif
+
+ifdef BUILD_SIMCODE
+LDFLAGS += -L$(PSLSE_ROOT)/libcxl
 endif
 
 libnameA = libsnap
@@ -55,7 +59,7 @@ $(libnameA).so.$(MAJOR_VERSION): $(libnameA).so.$(libversion)
 
 $(libnameA).so.$(libversion): __$(libnameA).o
 	$(CC) $(LDFLAGS) -shared  $(SONAMEA) \
-		 -o $@ $^ $(libsA)
+		 -o $@ $^ $(libsA) $(LDLIBS)
 
 install: all
 	mkdir -p $(LIB_INSTALL_PATH)

--- a/software/lib/snap.c
+++ b/software/lib/snap.c
@@ -204,10 +204,12 @@ static void *hw_snap_card_alloc_dev(const char *path,
 		goto __snap_alloc_err;
 	}
 
+#if !defined(_SIM_)
 	rc = cxl_mmio_ptr(afu_h, &dn->mmio_ptr);
 	if (rc != 0)
 		fprintf(stderr, "[%s] cannot get mmio_ptr rc=%d %s\n",
 			__func__, rc, strerror(errno));
+#endif
 
 	dn->action_base = 0;
 	cxl_mmio_read64(afu_h, SNAP_S_CIR, &reg);
@@ -274,6 +276,7 @@ static int hw_snap_mmio_read32(struct snap_card *card,
 	return rc;
 }
 
+#if !defined(_SIM_)
 /**
  * FIXME Currently experimental use. We like to figure out if extensive
  *       use of hwsync has negative impact on performance when # threads
@@ -298,6 +301,7 @@ int snap_mmio_read32_nohwsync(struct snap_card *card,
 
 	return 0;
 }
+#endif
 
 static int hw_snap_mmio_write64(struct snap_card *card,
 				uint64_t offset, uint64_t data)

--- a/software/lib/snap.c
+++ b/software/lib/snap.c
@@ -58,6 +58,11 @@ int cache_trace_enabled(void)
 	return snap_trace & 0x40;
 }
 
+int stat_trace_enabled(void)
+{
+	return snap_trace & 0x80;
+}
+
 #define simulation_enabled()  (snap_config & 0x01)
 
 #define snap_trace(fmt, ...) do {					\

--- a/software/lib/snap.c
+++ b/software/lib/snap.c
@@ -39,29 +39,34 @@ static unsigned int snap_trace = 0x0;
 static unsigned int snap_config = 0x0;
 static struct snap_sim_action *actions = NULL;
 
-#define snap_trace_enabled()  (snap_trace & 0x01)
-#define reg_trace_enabled()   (snap_trace & 0x02)
-#define sim_trace_enabled()   (snap_trace & 0x04)
-#define poll_trace_enabled()  (snap_trace & 0x10)
+#define snap_trace_enabled()  (snap_trace & 0x0001)
+#define reg_trace_enabled()   (snap_trace & 0x0002)
+#define sim_trace_enabled()   (snap_trace & 0x0004)
+#define poll_trace_enabled()  (snap_trace & 0x0010)
 
 int action_trace_enabled(void)
 {
-	return snap_trace & 0x08;
+	return snap_trace & 0x0008;
 }
 
 int block_trace_enabled(void)
 {
-	return snap_trace & 0x20;
+	return snap_trace & 0x0020;
 }
 
 int cache_trace_enabled(void)
 {
-	return snap_trace & 0x40;
+	return snap_trace & 0x0040;
 }
 
 int stat_trace_enabled(void)
 {
-	return snap_trace & 0x80;
+	return snap_trace & 0x0080;
+}
+
+int pp_trace_enabled(void)
+{
+	return snap_trace & 0x0100;
 }
 
 #define simulation_enabled()  (snap_config & 0x01)

--- a/software/scripts/snap_tests.sh
+++ b/software/scripts/snap_tests.sh
@@ -73,6 +73,8 @@ while getopts ":C:t:aMSHh" opt; do
 	esac
 done
 
+export LD_LIBRARY_PATH=./lib:$LD_LIBRARY_PATH
+
 ./tools/snap_peek --help > /dev/null || exit 1;
 ./tools/snap_poke --help > /dev/null || exit 1;
 

--- a/software/tools/Makefile
+++ b/software/tools/Makefile
@@ -24,7 +24,7 @@ LDLIBS += $(libs) -lpthread
 # Link statically for PSLSE simulation and dynamically for real version
 ifdef BUILD_SIMCODE
 libs += $(PSLSE_ROOT)/libcxl/libcxl.a
-CFLAGS+=-D_SIM_
+CFLAGS+=-D_SIM_ -I$(PSLSE_ROOT)/libcxl
 else
 LDLIBS += -lcxl
 endif


### PR DESCRIPTION
In this code we include several updates, fixes and enhancements to put together an NVMe block layer with LBA protection. We can prefetch in positive, negative or in both directions. Include also a prototype of a more flexible prediction approach, but that is not enabled yet.
