### PR TITLE
SNAP: capi_maint did not decode all actions.

### DIFF
--- a/software/tools/snap_maint.c
+++ b/software/tools/snap_maint.c
@@ -257,7 +257,7 @@ static bool decode_action(uint32_t atype)
 
 	for (i = 0; i < md_size; i++) {
 		if (atype == snap_actions[i].dev1) {
-			if (snap_actions[i].dev1 == snap_actions[i].dev2) {
+			if (atype <= snap_actions[i].dev2) {
 				VERBOSE1("%s %s\n", snap_actions[i].vendor,
 						snap_actions[i].description);
 				return true;

--- a/software/tools/snap_maint.c
+++ b/software/tools/snap_maint.c
@@ -256,7 +256,7 @@ static bool decode_action(uint32_t atype)
 	int md_size = sizeof(snap_actions)/sizeof(struct actions_tab);
 
 	for (i = 0; i < md_size; i++) {
-		if (atype == snap_actions[i].dev1) {
+		if (atype >= snap_actions[i].dev1) {
 			if (atype <= snap_actions[i].dev2) {
 				VERBOSE1("%s %s\n", snap_actions[i].vendor,
 						snap_actions[i].description);


### PR DESCRIPTION
Fix for Issue #523 
Need to use range for Action Types. (Start / Stop)

Signed-off-by: Eberhard S. Amann <esa@de.ibm.com>