### PR TITLE
Build: fixup auto lib build

### DIFF
--- a/actions/hdl_nvme_example/sw/Makefile
+++ b/actions/hdl_nvme_example/sw/Makefile
@@ -45,8 +45,7 @@ all: all_build
 #snap_cblk_libs += libsnapcblk.a
 #else
 snap_cblk_LDFLAGS += -L. \
-	-Wl,-rpath,$(SNAP_ROOT)/actions/hdl_nvme_example/sw \
-	-Wl,-rpath,$(SNAP_ROOT)/software/lib
+	-Wl,-rpath,$(SNAP_ROOT)/actions/hdl_nvme_example/sw
 
 snap_cblk_libs += -lsnapcblk -lrt
 #endif

--- a/actions/software.mk
+++ b/actions/software.mk
@@ -76,5 +76,5 @@ uninstall:
 	done
 
 clean distclean:
-	$(RM) $(projs) $(libs) *.o *.log *.out
+	$(RM) $(projs) $(libs) *.o *.log *.out *~
 

--- a/actions/software.mk
+++ b/actions/software.mk
@@ -25,14 +25,14 @@ endif
 include $(SNAP_ROOT)/software/config.mk
 
 CFLAGS += -std=c99 -I$(SNAP_ROOT)/software/include
-LDFLAGS += -L$(SNAP_ROOT)/software/lib
+LDFLAGS += -L$(SNAP_ROOT)/software/lib -Wl,-rpath,$(SNAP_ROOT)/software/lib
 LDLIBS += -lsnap -lcxl -lpthread
 LIBS += $(SNAP_ROOT)/software/lib/libsnap.so
 
 # Link statically for PSLSE simulation and dynamically for real version
 ifdef BUILD_SIMCODE
 CFLAGS += -D_SIM_
-LDFLAGS += -L$(PSLSE_ROOT)/libcxl
+LDFLAGS += -L$(PSLSE_ROOT)/libcxl -Wl,-rpath,$(PSLSE_ROOT)/libcxl
 LIBS += $(PSLSE_ROOT)/libcxl/libcxl.so
 endif
 

--- a/actions/software.mk
+++ b/actions/software.mk
@@ -47,6 +47,8 @@ all_build: $(projs)
 
 $(projs): $(LIBS) $(libs)
 
+$(libs): $(LIBS)
+
 $(PSLSE_ROOT)/libcxl/libcxl.so $(SNAP_ROOT)/software/lib/libsnap.so:
 	$(MAKE) -C `dirname $@`
 

--- a/actions/software.mk
+++ b/actions/software.mk
@@ -26,21 +26,14 @@ include $(SNAP_ROOT)/software/config.mk
 
 CFLAGS += -std=c99 -I$(SNAP_ROOT)/software/include
 LDFLAGS += -L$(SNAP_ROOT)/software/lib
-LDLIBS += -lsnap -lpthread
-
-DESTDIR ?= /usr
-# libs += $(SNAP_ROOT)/software/lib/libsnap.a
+LDLIBS += -lsnap -lcxl -lpthread
+LIBS += $(SNAP_ROOT)/software/lib/libsnap.so
 
 # Link statically for PSLSE simulation and dynamically for real version
 ifdef BUILD_SIMCODE
-# libs += $(PSLSE_ROOT)/libcxl/libcxl.a
 CFLAGS += -D_SIM_
 LDFLAGS += -L$(PSLSE_ROOT)/libcxl
-LDLIBS += -lcxl
-else
-# FIXME If we link against libsnap.so we should have this dependency covered.
-#      No -L<path_to_libcxl> required here, since it should be in the distro.
-LDLIBS += -lcxl
+LIBS += $(PSLSE_ROOT)/libcxl/libcxl.so
 endif
 
 # This rule should be the 1st one to find (default)
@@ -52,9 +45,9 @@ all: all_build
 # This rule needs to be behind all the definitions above
 all_build: $(projs)
 
-$(projs): $(libs)
+$(projs): $(LIBS) $(libs)
 
-$(PSLSE_ROOT)/libcxl/libcxl.a $(SNAP_ROOT)/software/lib/libsnap.a:
+$(PSLSE_ROOT)/libcxl/libcxl.so $(SNAP_ROOT)/software/lib/libsnap.so:
 	$(MAKE) -C `dirname $@`
 
 ### Deactivate existing implicit rule


### PR DESCRIPTION
This should address Alexandres problem where he tried to build his software application and libsnap.so was not build automatically. The circumvention was to build in the toplevel directory where the dependency to the library was correctly stated.