### PR TITLE
CBLK: Add flexible reqslot usage

### DIFF
--- a/software/include/capiblock.h
+++ b/software/include/capiblock.h
@@ -38,6 +38,10 @@
  */
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define NULL_CHUNK_ID  -1
 #define NULL_CHUNK_CG_ID NULL_CHUNK_ID
 
@@ -410,5 +414,9 @@ int cblk_cg_clone_after_fork(chunk_cg_id_t cgid,
                              int           flags);
 int cblk_cg_get_num_chunks(chunk_cg_id_t cgid,
                            int           flags);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _H_CFLASH_BLOCK */

--- a/software/include/snap_queue.h
+++ b/software/include/snap_queue.h
@@ -20,6 +20,9 @@
 
 #include <libsnap.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * CAPI Streaming Framework - Job Queue specific definitions
  */
@@ -76,5 +79,9 @@ struct snap_queue_workitem {
 		uint8_t data[112];	/* RAW Data Space to fill to 128 Bytes */
 	} user;
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*__SNAP_QUEUE_H__ */

--- a/software/include/snap_s_regs.h
+++ b/software/include/snap_s_regs.h
@@ -41,6 +41,7 @@ extern "C" {
 #define	SNAP_S_CCR	(SNAP_SLAVE_BASE + SNAP_CCR)
 #define	SNAP_S_CSR	(SNAP_SLAVE_BASE + SNAP_CSR)
 #define	SNAP_S_JCR	(SNAP_SLAVE_BASE + SNAP_JCR)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
I added code to do a parallel format and write if desired. Still 8KiB only. Performance for write is currently about 612MiB/sec instead of 230MiB/sec.