### PR TITLE
Defect #565: allow a simulation model build without a PSL DCP

### DIFF
--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -110,6 +110,7 @@ SNAP_TMP_FILES =  $(SNAP_HARDWARE_ROOT)/sim/README.txt \
 
 SNAP_ACTION_DCP=$(DCP_ROOT)/user_action_synth.dcp
 SNAP_BASE_DCP=$(DCP_ROOT)/snap_static_region_bb.dcp
+PSL_DCP_TYPE=$(shell $(SNAP_HARDWARE_ROOT)/snap_check_psl $(FPGACARD) $(PSL_DCP))
 
 #
 # FIXME Targets in this Makefile are to be build in the correct order.
@@ -119,7 +120,7 @@ SNAP_BASE_DCP=$(DCP_ROOT)/snap_static_region_bb.dcp
 
 ifeq ($(PLATFORM),x86_64)
 
-.PHONY: all snap_config check_snap_settings check_simulator check_nvme prepare_project snap_preprocess_start snap_preprocess_execute snap_preprocess patch_version patch_NVMe action_hw create_project hw_project_start hw_project .hw_project_done config image cloud_base cloud_action cloud_merge pslse software app model xsim irun nosim sim
+.PHONY: all snap_config check_snap_settings check_simulator check_nvme prepare_project snap_preprocess_start snap_preprocess_execute snap_preprocess patch_version patch_NVMe action_hw create_project hw_project_start hw_project config add_psl_dcp check_psl_dcp image cloud_base cloud_action cloud_merge pslse software app model xsim irun nosim sim
 
 all: model image
 
@@ -204,9 +205,6 @@ prepare_project: check_snap_settings prepare_logs
 	@ln -f -s $(SNAP_HARDWARE_ROOT)/setup/snap_build.tcl          $(BUILD_DIR)/snap_build.tcl;
 	@ln -f -s $(SNAP_HARDWARE_ROOT)/setup/snap_cloud_build.tcl    $(BUILD_DIR)/snap_cloud_build.tcl;
 	@ln -f -s $(SNAP_HARDWARE_ROOT)/setup/snap_cloud_merge.tcl    $(BUILD_DIR)/snap_cloud_merge.tcl;
-	@if [ -e "$(PSL_DCP)" ]; then \
-		cp -p $(PSL_DCP)                                             $(BUILD_DIR)/Checkpoints/; \
-	fi
 	@ln -f -s $(SNAP_HDL_CORE)/psl_fpga_$(FPGA_CARD).vhd_source   $(SNAP_HDL_CORE)/psl_fpga.vhd_source;
 	@ln -f -s $(SNAP_HDL_CORE)/psl_accel_$(FPGA_CARD).vhd_source  $(SNAP_HDL_CORE)/psl_accel.vhd_source;
 	@ln -f -s $(SNAP_SIM_CORE)/top_$(CAPI_VER).sv_source          $(SNAP_SIM_CORE)/top.sv_source;
@@ -285,7 +283,7 @@ action_hw: prepare_logs
 	@touch .create_ip_done
 
 .create_nvme_done:
-	@cd $(SNAP_HARDWARE_ROOT)/setup  &&  vivado -quiet -mode batch -source create_nvme_host.tcl -notrace -log $(LOGS_DIR)/create_nvme_host.log  -journal $(LOGS_DIR)/create_nvme_host.jou
+	@cd $(SNAP_HARDWARE_ROOT)/setup  &&  vivado -quiet -mode batch -source create_nvme_host.tcl -notrace -log $(LOGS_DIR)/create_nvme_host.log  -journal $(LOGS_DIR)/create_nvme_host.jou 
 	@touch .create_nvme_done
 
 create_project: snap_preprocess
@@ -293,7 +291,7 @@ create_project: snap_preprocess
 	@echo -e "                        using `vivado -version |grep Vivado`"
 	@$(MAKE) -s .create_ip_done
 	@if [ $(NVME_USED) = "TRUE" ]; then $(MAKE) -s .create_nvme_done; fi
-	@cd $(SNAP_HARDWARE_ROOT)/setup  &&  vivado  -quiet -mode batch -source create_framework.tcl -notrace -log $(LOGS_DIR)/create_framework.log  -journal $(LOGS_DIR)/create_framework.jou
+	@cd $(SNAP_HARDWARE_ROOT)/setup  &&  vivado -quiet -mode batch -source create_framework.tcl -notrace -log $(LOGS_DIR)/create_framework.log  -journal $(LOGS_DIR)/create_framework.jou
 	@$(MAKE) -s patch_NVMe
 	@echo -e "[CREATE PROJECT......] done  `date +"%T %a %b %d %Y"`"
 
@@ -311,7 +309,21 @@ hw_project: hw_project_start action_hw
 # Adding target 'config' for backward compatibility
 config: hw_project
 
-image: .hw_project_done
+# checking card type for PSL design checkpoint
+check_psl_dcp:
+	if [ "$(USE_PRFLOW)" != "TRUE" ]; then \
+		if [ "$(PSL_DCP_TYPE)" != "$(FPGACARD)" ]; then \
+			if [ "$(PSL_DCP_TYPE)" == *"OUTDATED"* ]; then \
+				echo "### ERROR ### PSL_DCP for $(FPGACARD) is pointing to an outdated design checkpoint."; exit -1; \
+			elif [ "$(PSL_DCP_TYPE)" == "" ]; then \
+				echo "### ERROR ###  PSL_DCP must point to the CAPI PSL Checkpoint file (b_route_design.dcp)."; exit -1; \
+			else  \
+				echo "### ERROR ### PSL_DCP is pointing to a checkpoint for a $(PSL_DCP_TYPE) card while FPGACARD is set to $(FPGACARD)."; exit -1; \
+			fi; \
+		fi; \
+	fi
+
+image: check_psl_dcp
 	@echo -e "[BUILD IMAGE.........] start `date +"%T %a %b %d %Y"`\n"
 ifeq ($(USE_PRFLOW),TRUE)
 	snap-cloud-build ${SNAP_ROOT}/snap_env.sh

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -120,7 +120,7 @@ PSL_DCP_TYPE=$(shell $(SNAP_HARDWARE_ROOT)/snap_check_psl $(FPGACARD) $(PSL_DCP)
 
 ifeq ($(PLATFORM),x86_64)
 
-.PHONY: all snap_config check_snap_settings check_simulator check_nvme prepare_project snap_preprocess_start snap_preprocess_execute snap_preprocess patch_version patch_NVMe action_hw create_project hw_project_start hw_project config add_psl_dcp check_psl_dcp image cloud_base cloud_action cloud_merge pslse software app model xsim irun nosim sim
+.PHONY: all snap_config check_snap_settings check_simulator check_nvme prepare_project snap_preprocess_start snap_preprocess_execute snap_preprocess patch_version patch_NVMe action_hw create_project hw_project_start hw_project .hw_project_done config add_psl_dcp check_psl_dcp image cloud_base cloud_action cloud_merge pslse software app model xsim irun nosim sim
 
 all: model image
 
@@ -162,20 +162,20 @@ check_snap_settings:
 	@echo "                        SDRAM_USED      = $(SDRAM_USED)"
 	@echo "                        NVME_USED       = $(NVME_USED)"
 	@echo "                        ILA_DEBUG       = $(ILA_DEBUG)"
-	@if [ `echo "$(ILA_DEBUG)" | tr a-z A-Z` = "TRUE" ]; then \
+	@if [ `echo "$(ILA_DEBUG)" | tr a-z A-Z` == "TRUE" ]; then \
 		echo "                        ILA_SETUP_FILE  = $(ILA_SETUP_FILE)"; \
 	fi
 	@echo "                        SIMULATOR       = $(SIMULATOR)"
 	@echo "                        USE_PRFLOW      = $(USE_PRFLOW)"
-	@if [ `echo "$(USE_PRFLOW)" | tr a-z A-Z` = "TRUE" ]; then \
+	@if [ `echo "$(USE_PRFLOW)" | tr a-z A-Z` == "TRUE" ]; then \
 		echo "                        CLOUD_USER_FLOW = $(CLOUD_USER_FLOW)"; \
 		echo "                        DCP_ROOT        = $(DCP_ROOT)"; \
 	fi
 	@echo "                        =============================="
 
 check_nvme:
-	@if [ $(SIMULATOR) != "nosim" ] && [ $(NVME_USED) = "TRUE" ]; then \
-		if [ $(SIMULATOR) != "irun" ]; then  \
+	@if [ "$(SIMULATOR)" != "nosim" ] && [ "$(NVME_USED)" == "TRUE" ]; then \
+		if [ "$(SIMULATOR)" != "irun" ]; then  \
 			echo "                        NVMe simulation is not supported for SIMULATOR $(SIMULATOR)"; \
 			exit -1; \
 		fi; \
@@ -188,7 +188,7 @@ check_nvme:
 	fi
 
 check_simulator:
-	@if [ $(SIMULATOR) != "irun" ] && [ $(SIMULATOR) != "xsim" ] && [ $(SIMULATOR) != "nosim" ]; then \
+	@if [ "$(SIMULATOR)" != "irun" ] && [ "$(SIMULATOR)" != "xsim" ] && [ "$(SIMULATOR)" != "nosim" ]; then \
 		echo "                        unknown simulator=$SIMULATOR"; \
 		exit -1; \
 	fi
@@ -231,7 +231,7 @@ $(SNAP_PP_FILES_VHD):
 	@$(RM) $@_tmp
 
 $(SNAP_SIM_NVME)/endp_4_pipe32.v:
-	@if [ $(SIMULATOR) != "nosim" ] && [ $(NVME_USED) = "TRUE" ]; then \
+	@if [ "$(SIMULATOR)" != "nosim" ] && [ "$(NVME_USED)" == "TRUE" ]; then \
 	  echo -e "                        generating $(notdir $@)"; \
 	  $(DENALI)/bin/pureview -batch -generate all . -genoutput  $(SNAP_SIM_NVME)/endp_4_pipe32.v $(SNAP_SIM_NVME)/endp_4_pipe32.soma > $(LOGS_DIR)/pureview.log 2>&1; \
 	  if [ $$? -ne 0 ]; then \
@@ -240,7 +240,7 @@ $(SNAP_SIM_NVME)/endp_4_pipe32.v:
 	fi
 
 snap_core_config:
-	@$(SNAP_HARDWARE_ROOT)/setup/snap_config.sh  $(SNAP_HDL_CORE)/snap_core_types.vhd 
+	@$(SNAP_HARDWARE_ROOT)/setup/snap_config.sh  $(SNAP_HDL_CORE)/snap_core_types.vhd
 
 %.vhd: %.vhd_source
 
@@ -255,7 +255,7 @@ patch_version:
 	$(SNAP_HARDWARE_ROOT)/setup/patch_version.sh $(SNAP_HDL_CORE) snap_core_types.vhd
 
 patch_NVMe:
-	@if [ -e "$(SNAP_HARDWARE_ROOT)/setup/patch_NVMe.sh" ] && [ $(NVME_USED) = "TRUE" ]; then \
+	@if [ -e "$(SNAP_HARDWARE_ROOT)/setup/patch_NVMe.sh" ] && [ "$(NVME_USED)" == "TRUE" ]; then \
 		echo -e "                        patching NVMe PCIe Root Complex sim files"; \
 		cd $(SNAP_HARDWARE_ROOT)/setup && ./patch_NVMe.sh && cd .. ; \
 	fi
@@ -270,7 +270,7 @@ action_hw: prepare_logs
 	@if [ $$? -ne 0 ]; then \
 		echo -e "                        Error: please look into $(LOGS_DIR)/action_make.log"; exit -1; \
 	fi
-	@if [ $(USE_PRFLOW) = "TRUE" ]; then \
+	@if [ "$(USE_PRFLOW)" == "TRUE" ]; then \
 		$(MAKE) -kC $(ACTION_ROOT)/hw vhdl >> $(LOGS_DIR)/action_make.log; \
 		if [ $$? -ne 0 ]; then \
 			echo -e "                        Error: please look into $(LOGS_DIR)/action_make.log"; exit -1; \
@@ -283,14 +283,14 @@ action_hw: prepare_logs
 	@touch .create_ip_done
 
 .create_nvme_done:
-	@cd $(SNAP_HARDWARE_ROOT)/setup  &&  vivado -quiet -mode batch -source create_nvme_host.tcl -notrace -log $(LOGS_DIR)/create_nvme_host.log  -journal $(LOGS_DIR)/create_nvme_host.jou 
+	@cd $(SNAP_HARDWARE_ROOT)/setup  &&  vivado -quiet -mode batch -source create_nvme_host.tcl -notrace -log $(LOGS_DIR)/create_nvme_host.log  -journal $(LOGS_DIR)/create_nvme_host.jou
 	@touch .create_nvme_done
 
 create_project: snap_preprocess
 	@echo -e "[CREATE PROJECT......] start `date +"%T %a %b %d %Y"`";
 	@echo -e "                        using `vivado -version |grep Vivado`"
 	@$(MAKE) -s .create_ip_done
-	@if [ $(NVME_USED) = "TRUE" ]; then $(MAKE) -s .create_nvme_done; fi
+	@if [ "$(NVME_USED)" == "TRUE" ]; then $(MAKE) -s .create_nvme_done; fi
 	@cd $(SNAP_HARDWARE_ROOT)/setup  &&  vivado -quiet -mode batch -source create_framework.tcl -notrace -log $(LOGS_DIR)/create_framework.log  -journal $(LOGS_DIR)/create_framework.jou
 	@$(MAKE) -s patch_NVMe
 	@echo -e "[CREATE PROJECT......] done  `date +"%T %a %b %d %Y"`"
@@ -310,10 +310,10 @@ hw_project: hw_project_start action_hw
 config: hw_project
 
 # checking card type for PSL design checkpoint
-check_psl_dcp: .hw_project_done 
+check_psl_dcp: .hw_project_done
 	if [ "$(USE_PRFLOW)" != "TRUE" ]; then \
 		if [ "$(PSL_DCP_TYPE)" != "$(FPGACARD)" ]; then \
-			if [ "$(PSL_DCP_TYPE)" == *"OUTDATED"* ]; then \
+			if [[ "$(PSL_DCP_TYPE)" == *"OUTDATED"* ]]; then \
 				echo "### ERROR ### PSL_DCP for $(FPGACARD) is pointing to an outdated design checkpoint."; exit -1; \
 			elif [ "$(PSL_DCP_TYPE)" == "" ]; then \
 				echo "### ERROR ###  PSL_DCP must point to the CAPI PSL Checkpoint file (b_route_design.dcp)."; exit -1; \

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -310,7 +310,7 @@ hw_project: hw_project_start action_hw
 config: hw_project
 
 # checking card type for PSL design checkpoint
-check_psl_dcp:
+check_psl_dcp: .hw_project_done 
 	if [ "$(USE_PRFLOW)" != "TRUE" ]; then \
 		if [ "$(PSL_DCP_TYPE)" != "$(FPGACARD)" ]; then \
 			if [ "$(PSL_DCP_TYPE)" == *"OUTDATED"* ]; then \

--- a/hardware/setup/create_framework.tcl
+++ b/hardware/setup/create_framework.tcl
@@ -56,12 +56,14 @@ if { [info exists ::env(CLOUD_USER_FLOW)] == 1 } {
   set cloud_user_flow "FALSE"
 }
 
-if { $cloud_user_flow == "FALSE" } {
-  if { $fpga_card == "N250SP" } {
-    set psl_dir     $::env(PSL_DCP)
+if { [info exists ::env(PSL_DCP)] == 1 } {
+  if { $cloud_user_flow == "TRUE" } {
+    set psl_dcp "FALSE"
   } else {
-    set psl_dcp     [file tail $::env(PSL_DCP)]
-  }  
+    set psl_dcp $::env(PSL_DCP)
+  }
+} else {
+  set psl_dcp "FALSE"
 }
 
 if { ($use_prflow == "TRUE") && ($hls_support == "TRUE") } {
@@ -287,16 +289,11 @@ if { $nvme_used == TRUE } {
 }
 
 # Add PSL
-if { $cloud_user_flow == "FALSE" } {
-  if { $fpga_card == "N250SP" } {
-    puts "                        adding PSL source files"
-    add_files -scan_for_includes $psl_dir >> $log_file
-   
-  } else {
+if { $psl_dcp != "FALSE" } {
   puts "                        importing PSL design checkpoint"
-  read_checkpoint -cell b $root_dir/build/Checkpoints/$psl_dcp -strict >> $log_file
-  }
+  read_checkpoint -cell b $psl_dcp -strict >> $log_file
 }
+
 
 if { $use_prflow == "TRUE" } {
   # Create PR Configuration

--- a/hardware/snap_check_psl
+++ b/hardware/snap_check_psl
@@ -20,19 +20,24 @@
 ############################################################################
 #
 
-export PSL_DCP_TYPE="UNKNOWN"
+if [[ $# -eq 2 ]]; then
+  FPGACARD=$1
+  PSL_DCP=$2
+else
+    exit
+fi 
 
-
-if [ "$FPGACARD" = "N250SP" ]; then
+if [[ "$FPGACARD" == "N250SP" ]]; then
   export PSL_DCP_TYPE=$FPGACARD
 else
-  PSL_MD5=`md5sum $1 | cut -d " " -f 1`
+  PSL_MD5=`md5sum $PSL_DCP | cut -d " " -f 1`
 
   case $PSL_MD5 in 
     '5bf24f90f52e6959e8e6082245a2ac3c')    export PSL_DCP_TYPE="N250S";;
     '1b1526c0d3cb61815c886f83d3b4f202')    export PSL_DCP_TYPE="ADKU3";;    
     '3fa538efab1bc3e3fabe06477445d314')    export PSL_DCP_TYPE="S121B";;    
-    'd051aa72ce08b60fd587a74a5146bf88')    export PSL_DCP_TYPE="N250S OUTDATED";;    
+    'd051aa72ce08b60fd587a74a5146bf88')    export PSL_DCP_TYPE="N250S OUTDATED";;  
+    *)                                     export PSL_DCP_TYPE="UNKNOWN";;  
   esac
 fi
 

--- a/hardware/snap_check_psl
+++ b/hardware/snap_check_psl
@@ -20,24 +20,24 @@
 ############################################################################
 #
 
-if [[ $# -eq 2 ]]; then
+if [ $# -eq 2 ]; then
   FPGACARD=$1
   PSL_DCP=$2
 else
     exit
-fi 
+fi
 
-if [[ "$FPGACARD" == "N250SP" ]]; then
+if [ "$FPGACARD" == "N250SP" ]; then
   export PSL_DCP_TYPE=$FPGACARD
 else
   PSL_MD5=`md5sum $PSL_DCP | cut -d " " -f 1`
 
-  case $PSL_MD5 in 
+  case $PSL_MD5 in
     '5bf24f90f52e6959e8e6082245a2ac3c')    export PSL_DCP_TYPE="N250S";;
-    '1b1526c0d3cb61815c886f83d3b4f202')    export PSL_DCP_TYPE="ADKU3";;    
-    '3fa538efab1bc3e3fabe06477445d314')    export PSL_DCP_TYPE="S121B";;    
-    'd051aa72ce08b60fd587a74a5146bf88')    export PSL_DCP_TYPE="N250S OUTDATED";;  
-    *)                                     export PSL_DCP_TYPE="UNKNOWN";;  
+    '1b1526c0d3cb61815c886f83d3b4f202')    export PSL_DCP_TYPE="ADKU3";;
+    '3fa538efab1bc3e3fabe06477445d314')    export PSL_DCP_TYPE="S121B";;
+    'd051aa72ce08b60fd587a74a5146bf88')    export PSL_DCP_TYPE="N250S OUTDATED";;
+    *)                                     export PSL_DCP_TYPE="UNKNOWN";;
   esac
 fi
 

--- a/snap_env
+++ b/snap_env
@@ -29,10 +29,10 @@ unset ACTION_ROOT
 unset PSLSE_ROOT
 unset ILA_SETUP_FILE
 unset DCP_ROOT
+unset config_script
+unset snap_env_info
 
 while [[ $# -gt 0 ]]; do
-  unset snap_env_info
-  unset config_script
   case "$1" in
     "config")
       snap_env_info=y
@@ -103,18 +103,16 @@ while [ -z "$SETUP_DONE" ]; do
     fi
     if [ -e "$PSL_DCP" ]; then
       # checking card type for PSL design checkpoint
-      PSL_DCP_TYPE=`$snapdir/hardware/snap_check_psl $PSL_DCP`
+      PSL_DCP_TYPE=`$snapdir/hardware/snap_check_psl $FPGACARD $PSL_DCP`
       if [ "$PSL_DCP_TYPE" != "$FPGACARD" ]; then
         if [[ "$PSL_DCP_TYPE" == *"OUTDATED"* ]]; then
-          SETUP_WARNING="$SETUP_WARNING\n### WARNING ### PSL_DCP for $FPGACARD is pointing to an outdated design checkpoint"
+          SETUP_INFO="$SETUP_INFO\n### INFO ### PSL_DCP for $FPGACARD is pointing to an outdated design checkpoint, image build will not allowed."
         else 
-          SETUP_WARNING="$SETUP_WARNING\n### WARNING ### PSL_DCP is pointing to a checkpoint for a $PSL_DCP_TYPE card while FPGACARD is set to $FPGACARD"
+          SETUP_INFO="$SETUP_INFO\n### INFO ### PSL_DCP is pointing to a checkpoint for a $PSL_DCP_TYPE card while FPGACARD is set to $FPGACARD, image build will not allowed."
         fi
       fi
-    elif [ -z "$PSL_DCP" ]; then
-      SETUP_EMPTY="$SETUP_EMPTY\n  PSL_DCP"
     else
-      SETUP_WARNING="$SETUP_WARNING\n### WARNING ### The environment variable PSL_DCP must point to the CAPI PSL Checkpoint file (b_route_design.dcp)."
+      SETUP_INFO="$SETUP_INFO\n### INFO ### For image build the environment variable PSL_DCP must point to the CAPI PSL Checkpoint file (b_route_design.dcp)."
     fi
   fi
 

--- a/snap_env
+++ b/snap_env
@@ -106,9 +106,9 @@ while [ -z "$SETUP_DONE" ]; do
       PSL_DCP_TYPE=`$snapdir/hardware/snap_check_psl $FPGACARD $PSL_DCP`
       if [ "$PSL_DCP_TYPE" != "$FPGACARD" ]; then
         if [[ "$PSL_DCP_TYPE" == *"OUTDATED"* ]]; then
-          SETUP_INFO="$SETUP_INFO\n### INFO ### PSL_DCP for $FPGACARD is pointing to an outdated design checkpoint, image build will not allowed."
+          SETUP_INFO="$SETUP_INFO\n### INFO ### PSL_DCP for $FPGACARD is pointing to an outdated design checkpoint, image build will not be allowed."
         else 
-          SETUP_INFO="$SETUP_INFO\n### INFO ### PSL_DCP is pointing to a checkpoint for a $PSL_DCP_TYPE card while FPGACARD is set to $FPGACARD, image build will not allowed."
+          SETUP_INFO="$SETUP_INFO\n### INFO ### PSL_DCP is pointing to a checkpoint for a $PSL_DCP_TYPE card while FPGACARD is set to $FPGACARD, image build will not be allowed."
         fi
       fi
     else

--- a/snap_env
+++ b/snap_env
@@ -92,7 +92,7 @@ while [ -z "$SETUP_DONE" ]; do
 
   ####### checking path to PSL design checkpoint
   # Note: CLOUD_USER_FLOW is defined via snap_config
-  if [ "$CLOUD_USER_FLOW" = "TRUE" ]; then
+  if [ "$CLOUD_USER_FLOW" == "TRUE" ]; then
     SETUP_INFO="$SETUP_INFO\n### INFO ### Cloud user flow is skipping PSL_DCP check"
   else
     echo "=====Checking path to PSL design checkpoint============"
@@ -107,7 +107,7 @@ while [ -z "$SETUP_DONE" ]; do
       if [ "$PSL_DCP_TYPE" != "$FPGACARD" ]; then
         if [[ "$PSL_DCP_TYPE" == *"OUTDATED"* ]]; then
           SETUP_INFO="$SETUP_INFO\n### INFO ### PSL_DCP for $FPGACARD is pointing to an outdated design checkpoint, image build will not be allowed."
-        else 
+        else
           SETUP_INFO="$SETUP_INFO\n### INFO ### PSL_DCP is pointing to a checkpoint for a $PSL_DCP_TYPE card while FPGACARD is set to $FPGACARD, image build will not be allowed."
         fi
       fi
@@ -176,17 +176,17 @@ while [ -z "$SETUP_DONE" ]; do
   else
     SNAP_ROOT=$snapdir
     eval ACTION_ROOT=$AR
-    if [ "$ignore_action_root" = "y" ]; then
+    if [ "$ignore_action_root" == "y" ]; then
       SETUP_INFO="$SETUP_INFO\n### INFO ### Skipping ACTION_ROOT check"
     elif [ ! -d "$ACTION_ROOT" ] && ( ( [ -z `echo "x$ACTION_ROOT" | grep -i /HLS` ] && [ "${HLS_SUPPORT^^}" != "TRUE" ] ) || [ `basename "x$ACTION_ROOT"` != "vhdl" ] ); then
       SETUP_WARNING="$SETUP_WARNING\n### WARNING ### Please make sure that ACTION_ROOT points to an existing directory."
-    fi  
+    fi
   fi
 
 
   ####### settings for ILA Debug
   # Note: ILA_DEBUG is defined via snap_config
-  if [ "$ILA_DEBUG" = "TRUE" ]; then
+  if [ "$ILA_DEBUG" == "TRUE" ]; then
     echo "=====ILA Debug setup==================================="
     echo "ILA_SETUP_FILE          is set to: \"$ILA_SETUP_FILE\""
     RESP=`grep ILA_SETUP_FILE $snap_env_sh`
@@ -205,7 +205,7 @@ while [ -z "$SETUP_DONE" ]; do
 
   ####### settings for Partial Reconfiguration flow
   # Note: USE_PRFLOW is defined via snap_config
-  if [ "$USE_PRFLOW" = "TRUE" ]; then
+  if [ "$USE_PRFLOW" == "TRUE" ]; then
     echo "=====PR flow setup====================================="
     RESP=`grep DCP_ROOT $snap_env_sh`
     if [ -z "$RESP" ]; then
@@ -220,7 +220,7 @@ while [ -z "$SETUP_DONE" ]; do
 
   ####### Cadence simulation setup:
   # Note: SIMULATOR is defined via snap_config
-  if [ "$SIMULATOR" = "irun" ]; then
+  if [ "$SIMULATOR" == "irun" ]; then
     echo "=====Cadence simulation setup=========================="
 
     if [ -z `which irun 2> /dev/null` ]; then
@@ -252,7 +252,7 @@ while [ -z "$SETUP_DONE" ]; do
   fi
 
   # Note: NVME_USED is defined via snap_config
-  if [[ "$NVME_USED" = "TRUE" ]]; then
+  if [[ "$NVME_USED" == "TRUE" ]]; then
     echo "=====Denali setup======================================"
     if [ -z "$DENALI" ]; then
       SETUP_INFO="$SETUP_INFO\n### INFO ### Setting of NVME_USED=$NVME_USED but DENALI not set!"
@@ -276,7 +276,7 @@ while [ -z "$SETUP_DONE" ]; do
     echo -e "All of the variables above have to be filled with the correct values."
   fi
 
-  if [ "$snap_env_info" = "y" ] && [ -n "$SETUP_INFO" ]; then
+  if [ "$snap_env_info" == "y" ] && [ -n "$SETUP_INFO" ]; then
     echo -e "$SETUP_INFO"
   fi
 
@@ -291,7 +291,7 @@ while [ -z "$SETUP_DONE" ]; do
 done
 
 if [ -z "$snap_env_info" ]; then
-  if [ "$0" = "bash" ]; then
+  if [ "$0" == "bash" ]; then
     # return value in case that this file was sourced
     return $RC
   else


### PR DESCRIPTION
If a user only wants to build a simulation model, no PSL DCP is required. 
Signed-off-by: Thomas Fuchs <thomas.fuchs@de.ibm.com>