### PR TITLE
Fix #578 HLS intersect: Split header files to sw-only and common

### DIFF
--- a/actions/hls_intersect/README.md
+++ b/actions/hls_intersect/README.md
@@ -4,7 +4,8 @@ Intersection has two methods and are implemented in two Actions.
 One is in hw_h (hash, -m1) and one is in hw_s (sort, -m2).
 You must configure it first (otherwise the default one is 'hash').
 
-Under $SNAP_ROOT/hardware directory
+After `make snap_config`, do this perticular step. (In case $ACTION_ROOT is not set, try to source snap_path.sh)
+
 ```
 make clean
 
@@ -16,9 +17,9 @@ make -C $ACTION_ROOT config_s
 
 Then follow the normal flow
 ``` 
-make config model
+make model
  .or. 
-make config image
+make image
 ```
 
 

--- a/actions/hls_intersect/README.md
+++ b/actions/hls_intersect/README.md
@@ -4,7 +4,7 @@ Intersection has two methods and are implemented in two Actions.
 One is in hw_h (hash, -m1) and one is in hw_s (sort, -m2).
 You must configure it first (otherwise the default one is 'hash').
 
-After `make snap_config`, do this perticular step. (In case $ACTION_ROOT is not set, try to source snap_path.sh)
+After `make snap_config`, do this particular step to select the method. (In case $ACTION_ROOT is not set, try to source snap_path.sh)
 
 ```
 make clean

--- a/actions/hls_intersect/hw_h/action_intersect_h.H
+++ b/actions/hls_intersect/hw_h/action_intersect_h.H
@@ -18,7 +18,7 @@
  */
 
 #include "hls_snap.H"
-#include "action_intersect.h"
+#include "action_intersect_common.h"
 
 //////////////////////////////////////
 // General

--- a/actions/hls_intersect/hw_s/action_intersect_s.H
+++ b/actions/hls_intersect/hw_s/action_intersect_s.H
@@ -18,7 +18,7 @@
  */
 
 #include "hls_snap.H"
-#include "action_intersect.h"
+#include "action_intersect_common.h"
 
 //////////////////////////////////////
 // General

--- a/actions/hls_intersect/include/action_intersect.h
+++ b/actions/hls_intersect/include/action_intersect.h
@@ -17,34 +17,13 @@
  * limitations under the License.
  */
 #include <snap_types.h>
+#include "action_intersect_common.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// Two hardware implementations and use two Action IDs
-// H for Hash method
-// S for Sort method
-#define INTERSECT_H_ACTION_TYPE 0x10141005
-#define INTERSECT_S_ACTION_TYPE 0x10141006
 
-#define NUM_TABLES  2
-#define MAX_TABLE_SIZE (uint64_t)(1<<30)
-
-#define HT_ENTRY_NUM_EXP 24
-#define HT_ENTRY_NUM (1<<HT_ENTRY_NUM_EXP)
-
-#define DIRECT_METHOD 0
-#define HASH_METHOD 1
-#define SORT_METHOD 2
-
-typedef struct intersect_job {
-	struct snap_addr src_tables_host[NUM_TABLES];	 /* input tables */
-	struct snap_addr src_tables_ddr[NUM_TABLES];	 /* input tables */
-	struct snap_addr result_table;             /* output table */
-    uint32_t step;
-    uint32_t method;
-} intersect_job_t;
 
 typedef char value_t[64];
 typedef unsigned int ptr_t;

--- a/actions/hls_intersect/include/action_intersect_common.h
+++ b/actions/hls_intersect/include/action_intersect_common.h
@@ -1,0 +1,54 @@
+#ifndef __ACTION_INTERSECT_COMMON_H__
+#define __ACTION_INTERSECT_COMMON_H__
+
+/*
+ * Copyright 2016, 2017, International Business Machines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <snap_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Two hardware implementations and use two Action IDs
+// H for Hash method
+// S for Sort method
+#define INTERSECT_H_ACTION_TYPE 0x10141005
+#define INTERSECT_S_ACTION_TYPE 0x10141006
+
+#define NUM_TABLES  2
+#define MAX_TABLE_SIZE (uint64_t)(1<<30)
+
+#define HT_ENTRY_NUM_EXP 24
+#define HT_ENTRY_NUM (1<<HT_ENTRY_NUM_EXP)
+
+#define DIRECT_METHOD 0
+#define HASH_METHOD 1
+#define SORT_METHOD 2
+
+typedef struct intersect_job {
+	struct snap_addr src_tables_host[NUM_TABLES];	 /* input tables */
+	struct snap_addr src_tables_ddr[NUM_TABLES];	 /* input tables */
+	struct snap_addr result_table;             /* output table */
+    uint32_t step;
+    uint32_t method;
+} intersect_job_t;
+
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif	/* __ACTION_INTERSECT_COMMON_H__ */


### PR DESCRIPTION
For Issue #578
For simulation in Vivado2017.4, some C data structure is more strictly checked by HLS (and set to ERROR). So I have to split the header files to 
* action_intersectXXXX.H (for `hw action`)
* action_intersectXXXX.h (for `sw action`) and 
* action_intersectXXXX_common.h (be included by the above two header files and for both.) 

Simulation passed now.  