### PR TITLE
CBLK: Add (and remove) circumvention to limit possible slots to 15 and not 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ In order to use the menu-driven user interface for kconfig the `ncurses` library
 SNAP uses the generic tools to update CAPI card FPGA bitstreams from
 * https://github.com/ibm-capi/capi-utils
 
-For simulation, SNAP relies on the `xterm` program and on the PSL Simulation Environment (PSLSE) which is available on github:
+For simulation, SNAP relies on the `xterm` program and on the PSL Simulation Environment (PSLSE) which is available on github (for more info see [PSLSE Setup](hardware/sim/README.md#pslse-setup)):
 * https://github.com/ibm-capi/pslse
 
 Simulating the NVMe host controller including flash storage devices requires licenses for the Cadence Incisive Simulator (IES) and DENALI Verification IP (PCIe and NVMe). Building images is possible without this.

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -163,7 +163,7 @@ static inline unsigned long atomic_inc(atomic_t *a)
 #define SNAP_N250S_NVME_SIZE (800ull * 1024 * 1024 * 1024) /* FIXME n TiB */
 #define __CBLK_BLOCK_SIZE 4096
 
-#define CBLK_IDX_MAX		15	/* FIXME Should be 16 */
+#define CBLK_IDX_MAX		16	/* FIXME Should be 16 */
 #define CBLK_NBLOCKS_MAX	32	/* 128 KiB / 4KiB */
 #define CBLK_NBLOCKS_WRITE_MAX	2	/* writing is just 1 or 2 blocks */
 

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -1747,7 +1747,7 @@ int cblk_read(chunk_id_t id __attribute__((unused)),
 
 	if (cblk_caching) {
 		/* Trying to get data from CACHE if we got all blocks ... */
-		rc = __cache_try_read(c, lba, buf, nblocks ,CONFIG_REQ_DURATION_USEC);
+		rc = __cache_try_read(c, lba, buf, nblocks, CONFIG_REQ_DURATION_USEC);
 
 		/* ... we don't need to ask the NVMe hardware */
 		if (rc == (int)nblocks) {

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -44,7 +44,7 @@
 #define CBLK_NBLOCKS			2 /* tuneup for the prefetch strategy */
 
 #define CONFIG_COMPLETION_THREADS	1 /* 1 works best */
-#define CONFIG_MAX_RETRIES		5 /* 5 is good, 0: no retries */
+#define CONFIG_MAX_RETRIES		0 /* 5 is good, 0: no retries */
 #define CONFIG_BUSY_TIMEOUT_SEC		5
 #define CONFIG_REQ_TIMEOUT_SEC		2
 #define CONFIG_REQ_DURATION_USEC	100000 /* usec */

--- a/actions/hdl_nvme_example/sw/snapblock.c
+++ b/actions/hdl_nvme_example/sw/snapblock.c
@@ -45,8 +45,8 @@
 
 #define CONFIG_COMPLETION_THREADS	1 /* 1 works best */
 #define CONFIG_MAX_RETRIES		0 /* 5 is good, 0: no retries */
-#define CONFIG_BUSY_TIMEOUT_SEC		5
-#define CONFIG_REQ_TIMEOUT_SEC		2
+#define CONFIG_BUSY_TIMEOUT_SEC		10
+#define CONFIG_REQ_TIMEOUT_SEC		5
 #define CONFIG_REQ_DURATION_USEC	100000 /* usec */
 
 static int cblk_maxretries = CONFIG_MAX_RETRIES;
@@ -112,14 +112,14 @@ static inline long int timediff_sec(struct timeval *a, struct timeval *b)
 
 	timersub(a, b , &res);
 
-	/* fprintf(stderr, "err: Strange time diff "
-	 * 	"a.tv_sec=%ld a.tv_usec=%ld "
-	 * 	"b.tv_sec=%ld b.tv_usec=%ld "
-	 * 	"r.tv_sec=%ld r.tv_usec=%ld\n",
-	 *		(long int)a->tv_sec, (long int)a->tv_usec,
-	 *	(long int)b->tv_sec, (long int)b->tv_usec,
-	 *	(long int)res.tv_sec, (long int)res.tv_usec);
-	 */
+	if (res.tv_sec > 100)
+		fprintf(stderr, "err: Strange time diff "
+			"a.tv_sec=%ld a.tv_usec=%ld "
+			"b.tv_sec=%ld b.tv_usec=%ld "
+			"r.tv_sec=%ld r.tv_usec=%ld\n",
+			(long int)a->tv_sec, (long int)a->tv_usec,
+			(long int)b->tv_sec, (long int)b->tv_usec,
+			(long int)res.tv_sec, (long int)res.tv_usec);
 
 	return res.tv_sec;
 }

--- a/hardware/setup/flash_mcs.tcl
+++ b/hardware/setup/flash_mcs.tcl
@@ -9,8 +9,8 @@ exec vivado -nolog -nojournal -mode batch -source "$0" -tclargs "$@"
 if { [info exists ::env(FPGACARD)] == 1 } {
     set fpgacard [string toupper $::env(FPGACARD)]
 } else {
-  set fpgacard "N250S"
-  puts "Warning: Environment FPGACARD is not set. Default to N250S"
+  set fpgacard "UNKNOWN"
+  #  puts "Warning: Environment FPGACARD is not set. Default to N250S"
 }
 
 proc flash_help {} {

--- a/hardware/sim/README.md
+++ b/hardware/sim/README.md
@@ -29,7 +29,7 @@ You may clone `PSLSE` from github [https://github.com/ibm-capi/pslse](https://gi
 
 :warning: Currently (as of Dec 2017) the following PSLSE GIT branches are necessary:
 * v3.1    (an older but stable master version) for POWER8 cards (ADKU3, N250S, S121B)
-* capi2   (a seperate side branch with more features) for POWER9 cards (N250S+)
+* capi2   (a separate side branch with more features) for POWER9 cards (N250S+)
 
 The plan is to merge both functionalities to master in 1Q2018
 

--- a/hardware/sim/testlist.sh
+++ b/hardware/sim/testlist.sh
@@ -252,7 +252,7 @@
  #
     if [[ "$t0l" == "10140001" || "${env_action}" == "hdl_nvme_example" ]];then echo -e "$del\ntesting hdl_nvme_example"
       step "snap_cblk -h"                                            # write max 2blk, read max 32blk a 512B
-      options="-n4 -t1"                                              # 512B blocks, one thread
+      options="-n32 -t1"                                              # 512B blocks, one thread
       export CBLK_BUSYTIMEOUT=350
       export CBLK_REQTIMEOUT=360
 #     export SNAP_TRACE=0xFFF
@@ -343,7 +343,7 @@
  #
     if [[ "$t0l" == "10141003" || "${env_action}" == "hls_search"* ]];then echo -e "$del\ntesting snap_search"
       step "snap_search -h"
-      for size in 1 2 30 257 1024 $rnd1k4k; do to=$((size*60+400))
+      for size in 1 2 30 257 1024 $rnd1k4k; do to=$((size*160+600))
         char=$(cat /dev/urandom|tr -dc 'a-zA-Z0-9'|fold -w 1|head -n 1)                               # one random ASCII  char to search for
         head -c $size </dev/zero|tr '\0' 'A' >${size}.uni                                             # same char mult times
         cat /dev/urandom|tr -dc 'a-zA-Z0-9'|fold -w ${size}|head -n 1 >${size}.rnd;head ${size}.rnd   # random data alphanumeric, includes EOF

--- a/hardware/sim/testlist.sh
+++ b/hardware/sim/testlist.sh
@@ -278,6 +278,7 @@
         step "snap_cblk $options -b2      --write cblk_read2.bin"
         step "snap_cblk $options -b${blk} --read  cblk_read3.bin"
         diff cblk_read2.bin cblk_read3.bin
+        rm cblk_read3.bin
       done
     fi # hdl_nvme_example
  #

--- a/hardware/sim/testlist.sh
+++ b/hardware/sim/testlist.sh
@@ -275,9 +275,8 @@
       diff cblk_read1.bin cblk_read2.bin
 
       for blk in 1 2 4 8 16 32;do byte=$((blk*512))
-        step "snap_cblk $options -b2      --write cbld_read2.bin"
-        step "snap_cblk $options -b${blk} --write cbld_read3.bin"
-        step "snap_cblk $options -b32     --read cclk_read.bin"
+        step "snap_cblk $options -b2      --write cblk_read2.bin"
+        step "snap_cblk $options -b${blk} --read  cblk_read3.bin"
         diff cblk_read2.bin cblk_read3.bin
       done
     fi # hdl_nvme_example

--- a/hardware/snap_check_psl
+++ b/hardware/snap_check_psl
@@ -34,9 +34,11 @@ else
 
   case $PSL_MD5 in
     '5bf24f90f52e6959e8e6082245a2ac3c')    export PSL_DCP_TYPE="N250S";;
-    '1b1526c0d3cb61815c886f83d3b4f202')    export PSL_DCP_TYPE="ADKU3";;
-    '3fa538efab1bc3e3fabe06477445d314')    export PSL_DCP_TYPE="S121B";;
-    'd051aa72ce08b60fd587a74a5146bf88')    export PSL_DCP_TYPE="N250S OUTDATED";;
+    '3a2d162828aed3cb271d1151be9bfdde')    export PSL_DCP_TYPE="N250S";; # with reset fix 20171220
+    '1b1526c0d3cb61815c886f83d3b4f202')    export PSL_DCP_TYPE="ADKU3";;    
+    'f920e532c7dfea8aa7c0f90db5b54bff')    export PSL_DCP_TYPE="ADKU3";; # with reset fix 20171220
+    '3fa538efab1bc3e3fabe06477445d314')    export PSL_DCP_TYPE="S121B";;    
+    'd051aa72ce08b60fd587a74a5146bf88')    export PSL_DCP_TYPE="N250S OUTDATED";;    
     *)                                     export PSL_DCP_TYPE="UNKNOWN";;
   esac
 fi

--- a/software/tools/snap_find_card
+++ b/software/tools/snap_find_card
@@ -27,18 +27,23 @@
 bold=$(tput bold)
 normal=$(tput sgr0)
 
-version=1.0
+# modified jan 16th 2018 to have -v option providing extra information
+version=1.1
 accel=UNKNOWN
+VERBOSE=0
 
 # Print usage message helper function
 function usage() {
 	echo "Usage: $PROGRAM"
+        echo "    [-v] Prints extra information (to be put as first param)"
 	echo "    [-A] <accelerator> use either GZIP, ADKU3, N250S, S121B or ALL"
 	echo "    [-C] <0..3> Print accelerator name for this Card"
+	echo "    [-V] provides version"
 	echo "  prints out a list of cards found for the accelerator."
 	echo "  The numbers reflect /dev/cxl/afu<n>.0."
 	echo "  Print a list of all cards found if -A ALL."
-	echo "  Print Accelerator Name if -C (0..3) is used."
+        echo "  Print a list of all cards found from a specific provider (-A N250S or ADKU3 or NSA121B or GZIP)"
+	echo "  Print card name if -C (0..3) is used."
 }
 
 #
@@ -61,12 +66,28 @@ function detect_snap_cards() {
 
 		psl_revision=`cat /sys/class/cxl/card${card}/psl_revision`
 		device=`cat /sys/class/cxl/card${card}/afu${card}.0/cr0/device`
+		image_loaded=`cat /sys/class/cxl/card${card}/image_loaded`
+		load_image_on_perst=`cat /sys/class/cxl/card${card}/load_image_on_perst`
 		if [ $device != $check_dev ]; then
 			continue
 		fi
 		sub=`cat /sys/class/cxl/card$card/device/subsystem_device`
 		if [ $sub = $check_sub ]; then
-			echo -n "${card} "
+			if [ $VERBOSE -eq 1 ] ; then
+				if [ $accel != ALL ] ; then
+				echo -e "A $accel card has been detected in card position ${card} "
+				else 
+                                echo -e "An acceleration card has been detected in card position ${card} "
+				fi
+				psl_revision_hex=`printf '0x%x\n' ${psl_revision}`
+				echo " PSL Revision is                                                : ${psl_revision_hex}"
+                                echo -e " Device ID    is                                                : ${check_dev}"
+                                echo -e " Sub device   is                                                : ${check_sub}"
+				echo -e " Image loaded is                                                : ${image_loaded}"
+				echo -e " Next image to be loaded at next reset (load_image_on_perst) is : ${load_image_on_perst}"
+			else
+				echo -n "${card} "
+			fi
 			rc=$((rc +1))
 		fi
 	done
@@ -106,6 +127,7 @@ function detect_card_name()
 	local dev=$2
 	local sub=$3
 	local name=$4
+	
 
 	if [ -d /sys/class/cxl/card${card} ]; then
 		psl_revision=`cat /sys/class/cxl/card${card}/psl_revision`
@@ -120,7 +142,11 @@ function detect_card_name()
 			if [ $this_dev = $dev ]; then
 				this_sub=`cat /sys/class/cxl/card$card/device/subsystem_device`
 				if [ $this_sub = $sub ]; then
+				        if [ $VERBOSE -eq 1 ] ; then
+						echo -e "Card $card is detected as $name card"
+					else
 					echo -n $name
+					fi
 					return 1
 				fi
 			fi
@@ -133,8 +159,11 @@ function detect_card_name()
 # Parse any options given on the command line
 
 PROGRAM=$0
-while getopts ":A:C:Vvh" opt; do
+while getopts ":vA:C:Vh" opt; do
 	case ${opt} in
+	v)
+		VERBOSE=1
+		;;
 	A)
 		accel=${OPTARG};
 		;;


### PR DESCRIPTION
It appears to be more stable than the 16 req slot version and might be ok to try as circumvention until real problem is found.

Signed-off-by: Frank Haverkamp <haver@linux.vnet.ibm.com>