### PR TITLE
SR_10425625 fix

### DIFF
--- a/hardware/hdl/core/dma_buffer_capi20.vhd_source
+++ b/hardware/hdl/core/dma_buffer_capi20.vhd_source
@@ -318,8 +318,8 @@ BEGIN
       dinb                   => (OTHERS => '0'),
       doutb                  => wram_rdata_reordered
     );
-    wram_rdata_reordered( 575 DOWNTO   0) <= wram_rdata(1151 DOWNTO 576);
-    wram_rdata_reordered(1151 DOWNTO 576) <= wram_rdata( 575 DOWNTO   0);
+    wram_rdata(1151 DOWNTO 576) <= wram_rdata_reordered( 575 DOWNTO   0) ;
+    wram_rdata( 575 DOWNTO   0) <= wram_rdata_reordered(1151 DOWNTO 576) ;
 
   ------------------------------------------------------------------------------
   ------------------------------------------------------------------------------

--- a/hardware/setup/create_framework.tcl
+++ b/hardware/setup/create_framework.tcl
@@ -271,9 +271,6 @@ if { $nvme_used == TRUE } {
   add_files -norecurse                          $ip_dir/nvme/nvme.srcs/sources_1/bd/nvme_top/nvme_top.bd  >> $log_file
   export_ip_user_files -of_objects  [get_files  $ip_dir/nvme/nvme.srcs/sources_1/bd/nvme_top/nvme_top.bd] -lib_map_path [list {modelsim=$root_dir/viv_project/framework.cache/compile_simlib/modelsim} {questa=$root_dir/viv_project/framework.cache/compile_simlib/questa} {ies=$root_dir/viv_project/framework.cache/compile_simlib/ies} {vcs=$root_dir/viv_project/framework.cache/compile_simlib/vcs} {riviera=$root_dir/viv_project/framework.cache/compile_simlib/riviera}] -force -quiet
   update_compile_order -fileset sources_1
-  puts "                        generating NVMe output products"
-  set_property synth_checkpoint_mode None [get_files  $ip_dir/nvme/nvme.srcs/sources_1/bd/nvme_top/nvme_top.bd] >> $log_file
-  generate_target all                     [get_files  $ip_dir/nvme/nvme.srcs/sources_1/bd/nvme_top/nvme_top.bd] >> $log_file
 
   if { $simulator != "nosim" } {
     puts "                        adding Denali simulation files"

--- a/hardware/setup/create_nvme_host.tcl
+++ b/hardware/setup/create_nvme_host.tcl
@@ -24,9 +24,11 @@ set log_file   $log_dir/create_nvme_host.log
 set prj_name nvme
 set bd_name  nvme_top
 
-puts "\[CREATE_NVMe.........\] start [clock format [clock seconds] -format {%T %a %b %d %Y}]"
 # Create NVME project
+puts "\[CREATE_NVMe.........\] start [clock format [clock seconds] -format {%T %a %b %d %Y}]"
 create_project   $prj_name $root_dir/ip/nvme -part $fpga_part -force >> $log_file
+set_property target_language VERILOG [current_project]
+#Create block design
 create_bd_design $bd_name  >> $log_file
 
 # Create NVME_HOST IP
@@ -335,10 +337,14 @@ create_bd_addr_seg -range 0x00001000 -offset 0x00000000 [get_bd_addr_spaces ACT_
 exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces ACT_NVME_AXI] [get_bd_addr_segs axi_pcie3_0/S_AXI_CTL/CTL0] >> $log_file
 exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces ACT_NVME_AXI] [get_bd_addr_segs axi_pcie3_1/S_AXI_CTL/CTL0] >> $log_file
 
-#### Save block design and close the project
+# Save block design and close the project
 save_bd_design >> $log_file
 
+# Generate the Output products of the NVME block design. It is important that this are Verilog files
+puts "                        generating NVMe output products"
+generate_target all [get_files  $root_dir/ip/nvme/nvme.srcs/sources_1/bd/nvme_top/nvme_top.bd] >> $log_file
 puts "\[CREATE_NVMe.........\] done  [clock format [clock seconds] -format {%T %a %b %d %Y}]"
  
+#Close the project
 close_project >> $log_file
 

--- a/hardware/setup/create_nvme_host.tcl
+++ b/hardware/setup/create_nvme_host.tcl
@@ -340,9 +340,11 @@ exclude_bd_addr_seg -target_address_space [get_bd_addr_spaces ACT_NVME_AXI] [get
 # Save block design and close the project
 save_bd_design >> $log_file
 
-# Generate the Output products of the NVME block design. It is important that this are Verilog files
+# Generate the Output products of the NVME block design. 
+# It is important that this are Verilog files and set the synth_checkpoint_mode to None (Global synthesis) before generating targets 
 puts "                        generating NVMe output products"
-generate_target all [get_files  $root_dir/ip/nvme/nvme.srcs/sources_1/bd/nvme_top/nvme_top.bd] >> $log_file
+set_property synth_checkpoint_mode None [get_files  $root_dir/ip/nvme/nvme.srcs/sources_1/bd/nvme_top/nvme_top.bd] >> $log_file 
+generate_target all                     [get_files  $root_dir/ip/nvme/nvme.srcs/sources_1/bd/nvme_top/nvme_top.bd] >> $log_file
 puts "\[CREATE_NVMe.........\] done  [clock format [clock seconds] -format {%T %a %b %d %Y}]"
  
 #Close the project


### PR DESCRIPTION
This fixed the "NVME, empty axi_pcie3_0_0_pcie3_ip.v in vivado 2017.4" problem (#596) .  The solution is to create the NVME output products in create_nvme_host.tcl instead of create_framework.tcl