### PR TITLE
HW: Don't clean pslse on hardware clean

### DIFF
--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -486,9 +486,4 @@ clean:
 			echo -e "                        Error: [make "$@"] failed for action/application in $(ACTION_ROOT)"; exit -1; \
 		fi                                          \
 	fi
-	if [ -d "$(PSLSE_ROOT)" ]; then					\
-		for d in afu_driver/src pslse libcxl debug ; do		\
-			$(MAKE) -C $(PSLSE_ROOT)/$$d $@ ;		\
-		done							\
-	fi
 	@echo -e "[CLEAN ENVIRONMENT...] done  `date +"%T %a %b %d %Y"`"


### PR DESCRIPTION
Cleaning PSLSE on each call of  `make clean` within the SNAP framework is breaking the shared usage of one PSLSE clone by multiple SNAP clones (sandboxes).