### PR TITLE
Adding Kconfig help messages - cosmetics changes

### DIFF
--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -326,6 +326,11 @@ config ENABLE_PRFLOW
         help 
           Used for Cloud environment using specific PSL images
 
+config USE_PRFLOW
+        string
+        default "TRUE" if ENABLE_PRFLOW
+        default "FALSE" if ! ENABLE_PRFLOW
+
 config ENABLE_ILA
         bool "Enable ILA Debug (Definition of $ILA_SETUP_FILE required)"
         depends on ! ENABLE_PRFLOW
@@ -352,11 +357,6 @@ config FACTORY_IMAGE
         string
         default "TRUE"  if ENABLE_FACTORY
         default "FALSE" if ! ENABLE_FACTORY
-
-config USE_PRFLOW
-        string
-        default "TRUE" if ENABLE_PRFLOW
-        default "FALSE" if ! ENABLE_PRFLOW
 
 config ENABLE_CLOUD_USER_FLOW
         bool "Cloud user flow"

--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -9,6 +9,7 @@ choice
         bool "Card Type"
         default N250S
         help
+          Card Type
           There are multiple card the framework supports. Please select
           one of them.
 
@@ -38,6 +39,7 @@ choice
                 select CAPI10
                 help
                   Semptian NSA121B has ethernet and 8GB DDR4 SDRAM. Uses Xilinx FPGA XCKU115.
+
 endchoice
 
 config FPGACARD
@@ -73,6 +75,12 @@ config NUM_OF_ACTIONS
 
 choice
         bool "Action Type"
+        help
+          Action Type
+          Select an Action type example:
+          - HDL for VHDL or Verilog coded examples
+          - HLS for C coded examples compiled with HLS
+
         default HDL_EXAMPLE
 
         config HLS_ACTION
@@ -102,12 +110,26 @@ choice
 
         config HLS_MEMCOPY
             bool "HLS Memcopy"
+            help
+               This is a basic example to start accessing data:
+               - Read data from the server memory or from the card DDR
+               - Write data to the server memory or to the card DDR
+               - A temporary buffer is used in the FPGA (configurable size)
+               All combination can be done. 
+               This example is written in C and compiled with HLS
             select ENABLE_HLS_SUPPORT
             select FORCE_SDRAM_OR_BRAM
             select DISABLE_NVME
 
         config HLS_SPONGE
             bool "HLS Sponge"
+            help
+               This is an example of a C code ported and optimized:
+               It is a benchmark to measure the SHA3 key generation performance
+               - Data are generated in the algorithm - No data move
+               - 3 functions : SPEED, SHA3, SHAKE (and SHA3_SHAKE)
+               - only the SPEED test was optimized
+               This example is written in C and compiled with HLS
             select ENABLE_HLS_SUPPORT
             select DISABLE_SDRAM_AND_BRAM
             select DISABLE_NVME
@@ -120,6 +142,14 @@ choice
 
         config HLS_SEARCH
             bool "HLS Search"
+            help
+               This example shows different ways to work with data:
+               - Read a pattern and text from the server memory
+               - search the pattern within the text 
+                    (2 methods used : text bufferized - stream flow)
+               - send back the number of occurrences
+               No optmization was done on this example
+               This example is written in C and compiled with HLS
             select ENABLE_HLS_SUPPORT
             select FORCE_SDRAM_OR_BRAM
             select DISABLE_NVME
@@ -145,6 +175,12 @@ choice
 
         config HLS_HELLOWORLD
             bool "HLS HelloWorld"
+            help
+               This is the simplest example to start with:
+               - Reading text from the server memory
+               - Processing changing case of the text 
+               - Writing back the text to the server memory
+               This example is written in C and compiled with HLS
             select ENABLE_HLS_SUPPORT
             select DISABLE_SDRAM_AND_BRAM
             select DISABLE_NVME
@@ -262,10 +298,14 @@ choice
 
         config SIM_XSIM
             bool "xsim"
+            help
+               Default Xilinx simulator
             depends on ! ENABLE_NVME
 
         config SIM_IRUN
             bool "irun"
+            help
+               Cadence simulator (requires a sepcific license)
             depends on ! ENABLE_PRFLOW
 
         config NO_SIM
@@ -281,10 +321,16 @@ config SIMULATOR
 
 comment "================= Advanced Options: ================="
 
+config ENABLE_PRFLOW
+        bool "Cloud build (enabling Partial Reconfiguration)"
+        help 
+          Used for Cloud environment using specific PSL images
+
 config ENABLE_ILA
         bool "Enable ILA Debug (Definition of $ILA_SETUP_FILE required)"
         depends on ! ENABLE_PRFLOW
         help
+          Used for debugging the design by inserting probes into the FPGA
           Enable the usage of Vivado's integrated logic analyzer.
           Please make sure that $ILA_SETUP_FILE points to the .xdc file
           defining the debug cores.
@@ -296,15 +342,16 @@ config ILA_DEBUG
 
 config ENABLE_FACTORY
         bool "Create Factory Image"
+        help 
+          Used to generate a specific image to be located into the factory area
+          Default image is in the user area. 
+          This specific fcatory area is used to recover from a bad user image
         depends on ! ENABLE_PRFLOW
 
 config FACTORY_IMAGE
         string
         default "TRUE"  if ENABLE_FACTORY
         default "FALSE" if ! ENABLE_FACTORY
-
-config ENABLE_PRFLOW
-        bool "Cloud build (enabling Partial Reconfiguration)"
 
 config USE_PRFLOW
         string
@@ -323,6 +370,8 @@ config CLOUD_USER_FLOW
 
 config ENABLE_CLOUD_BUILD_BITFILE
         bool "Build bitstream file"
+        help
+          Enables the generation of the image for the FPGA
         default y
         depends on ENABLE_PRFLOW
 

--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -11,7 +11,7 @@ choice
         help
           Card Type
           There are multiple card the framework supports. Please select
-          one of them.
+          one of them. Pay attention to CAPI level (eg CAPI10 or CAPI20)
 
         config N250S
                 bool "Nallatech 250S with 4GB DDR4 SDRAM, NVMe and Xilinx KU60 FPGA"
@@ -305,7 +305,7 @@ choice
         config SIM_IRUN
             bool "irun"
             help
-               Cadence simulator (requires a sepcific license)
+               Cadence simulator (requires a specific license)
             depends on ! ENABLE_PRFLOW
 
         config NO_SIM
@@ -345,7 +345,7 @@ config ENABLE_FACTORY
         help 
           Used to generate a specific image to be located into the factory area
           Default image is in the user area. 
-          This specific fcatory area is used to recover from a bad user image
+          This specific factory area is used to recover from a bad user image
         depends on ! ENABLE_PRFLOW
 
 config FACTORY_IMAGE

--- a/software/lib/snap.c
+++ b/software/lib/snap.c
@@ -69,7 +69,7 @@ int pp_trace_enabled(void)
 	return snap_trace & 0x0100;
 }
 
-#define simulation_enabled()  (snap_config & 0x01)
+#define software_action_enabled()  (snap_config & 0x01)
 
 #define snap_trace(fmt, ...) do { \
 		if (snap_trace_enabled()) \
@@ -666,7 +666,7 @@ struct snap_action *snap_attach_action(struct snap_card *card,
 				       snap_action_flag_t action_flags,
 				       int timeout_ms)
 {
-	if (simulation_enabled())
+	if (software_action_enabled())
 		snap_map_funcs(card, action_type);
 
 	return df->attach_action(card, action_type, action_flags, timeout_ms);
@@ -1292,6 +1292,6 @@ static void _init(void)
 		}
 	}
 
-	if (simulation_enabled())
+	if (software_action_enabled())
 		df = &software_funcs; /* Map Software Functions */
 }


### PR DESCRIPTION
Signed-off-by: Bruno Mesnet <bruno.mesnet@fr.ibm.com>
- Kconfig : Adding help messages to different choices
- Kconfig : moving above the **Cloud build** option as first choice of Advanced option so that selecting it or not, the display stays at the same place (no functionality changes, just a cosmetic change)
- software/lib/snap.c : Answers Issue#432 - renaming a variable to be coherent