### PR TITLE
HW: Modifying PSL check for image and model build

### DIFF
--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -120,7 +120,7 @@ PSL_DCP_TYPE=$(shell $(SNAP_HARDWARE_ROOT)/snap_check_psl "$(FPGACARD)" "$(PSL_D
 
 ifeq ($(PLATFORM),x86_64)
 
-.PHONY: all snap_config check_snap_settings check_simulator check_nvme prepare_project snap_preprocess_start snap_preprocess_execute snap_preprocess patch_version patch_NVMe action_hw create_project hw_project_start hw_project .hw_project_done config add_psl_dcp check_psl_dcp image cloud_base cloud_action cloud_merge pslse software app model xsim irun nosim sim
+.PHONY: all snap_config check_snap_settings check_simulator check_nvme prepare_project snap_preprocess_start snap_preprocess_execute snap_preprocess patch_version patch_NVMe action_hw create_project hw_project_start hw_project .hw_project_done config add_psl_dcp check_psl image cloud_base cloud_action cloud_merge pslse software app model xsim irun nosim sim
 
 all: model image
 
@@ -317,9 +317,13 @@ hw_project: hw_project_start action_hw
 config: hw_project
 
 # checking card type for PSL design checkpoint
-check_psl_dcp: .hw_project_done
+check_psl:
 	if [ "$(USE_PRFLOW)" != "TRUE" ]; then \
-		if [ "$(PSL_DCP_TYPE)" != "$(FPGACARD)" ]; then \
+		if [ "$(FPGACARD)" == "N250SP" ]; then \
+			if [ -z "$(PSL4N250SP_ROOT)" ]; then \
+				echo "### ERROR ###  Environment variable PSL4N250SP_ROOT is undefined. It has to point to the PSL IP sources."; exit -1; \
+			fi; \
+		elif [ "$(PSL_DCP_TYPE)" != "$(FPGACARD)" ]; then \
 			if [[ "$(PSL_DCP_TYPE)" == *"OUTDATED"* ]]; then \
 				echo "### ERROR ### PSL_DCP for $(FPGACARD) is pointing to an outdated design checkpoint."; exit -1; \
 			elif [ "$(PSL_DCP_TYPE)" == "" ]; then \
@@ -330,7 +334,8 @@ check_psl_dcp: .hw_project_done
 		fi; \
 	fi
 
-image: check_psl_dcp
+image: check_psl
+	$(MAKE) .hw_project_done
 	@echo -e "[BUILD IMAGE.........] start `date +"%T %a %b %d %Y"`\n"
 ifeq ($(USE_PRFLOW),TRUE)
 	snap-cloud-build ${SNAP_ROOT}/snap_env.sh

--- a/hardware/setup/create_framework.tcl
+++ b/hardware/setup/create_framework.tcl
@@ -104,7 +104,7 @@ set_property STEPS.WRITE_BITSTREAM.TCL.POST $root_dir/setup/snap_bitstream_post.
 puts "                        importing design files"
 # HDL Files
 add_files -scan_for_includes $hdl_dir/core/  >> $log_file
-if { $fpga_card == "N250SP" } {
+if { ($fpga_card == "N250SP") && ($psl4n250sp_dir != "not defined") } {
   puts "                        importing psl4n250sp source files"
   add_files -scan_for_includes $psl4n250sp_dir/src/  >> $log_file
   add_files -scan_for_includes $psl4n250sp_dir/FlashGTPlus/hdk/src/  >> $log_file
@@ -258,7 +258,7 @@ if { $nvme_used == TRUE } {
 }
 
 # Add PSL
-if { $fpga_card == "N250SP" } {
+if { ($fpga_card == "N250SP") && ($psl4n250sp_dir != "not defined") } {
   set_property "ip_repo_paths" "[file normalize "$psl4n250sp_dir/FlashGTPlus/psl/ip_repo"]" [current_project]
   update_ip_catalog >> $log_file
   add_files -norecurse                          $ip_dir/pcie4_uscale_plus_0/pcie4_uscale_plus_0.xci
@@ -282,7 +282,7 @@ set_property used_in_synthesis false [get_files  $root_dir/setup/snap_link.xdc]
 update_compile_order -fileset sources_1 >> $log_file
 
 # PSL4N250SP XDC
-if { $fpga_card == "N250SP" } {
+if { ($fpga_card == "N250SP") && ($psl4n250sp_dir != "not defined") } {
   puts "                            importing psl4n250sp XDCs"
   #add_files -fileset constrs_1 -norecurse $psl4n250sp_dir/setup/xdc/psl4n250sp_config.xdc
   add_files -fileset constrs_1 -norecurse $psl4n250sp_dir/setup/xdc/psl4n250sp_timing.xdc

--- a/hardware/setup/create_ip.tcl
+++ b/hardware/setup/create_ip.tcl
@@ -48,7 +48,7 @@ set_property target_language VHDL [current_project]
 set_property target_simulator IES [current_project]
 
 #create PSL/HDK IP for N250SP
-if { $fpga_card == "N250SP" } {
+if { ($fpga_card == "N250SP") && ($psl4n250sp_dir != "not defined") } {
   puts "                        generating PSL for SNAP IP"
 
   # Set IP repository paths

--- a/hardware/snap_check_psl
+++ b/hardware/snap_check_psl
@@ -19,32 +19,36 @@
 ############################################################################
 ############################################################################
 #
-
-if [ $# -eq 2 ]; then
+if [ $# -gt 1 ]; then
   FPGACARD=$1
   PSL_DCP=$2
+
+  if [ "$FPGACARD" == "N250SP" ]; then
+    export PSL_DCP_TYPE=$FPGACARD
+  else
+    if [ -n "$PSL_DCP" ]; then
+      PSL_MD5=`md5sum $PSL_DCP | cut -d " " -f 1`
+    else
+      PSL_MD5="UNKNOWN"
+    fi
+
+    case $PSL_MD5 in
+      '5bf24f90f52e6959e8e6082245a2ac3c')    export PSL_DCP_TYPE="N250S";;
+      '3a2d162828aed3cb271d1151be9bfdde')    export PSL_DCP_TYPE="N250S";; # with reset fix 20171220
+      'd7196d64990594f6c267aa8192a41573')    export PSL_DCP_TYPE="N250S";; # with reset fix 20180212 + vivado 2017.4
+      '1b1526c0d3cb61815c886f83d3b4f202')    export PSL_DCP_TYPE="ADKU3";;
+      'f920e532c7dfea8aa7c0f90db5b54bff')    export PSL_DCP_TYPE="ADKU3";; # with reset fix 20171220
+      '51b64ad40a3dc54ec855d7d7dfef0896')    export PSL_DCP_TYPE="ADKU3";; # rblack_PSLrev6_v174_20170122_vsec400
+      '3fa538efab1bc3e3fabe06477445d314')    export PSL_DCP_TYPE="S121B";;
+      '8602200acb12d2de68c2a8a95735571a')    export PSL_DCP_TYPE="S121B";;
+      '400d13185ce03f38776d672690618b2e')    export PSL_DCP_TYPE="S121B";; # psl233_viv17.4_vsec400h_Feb23
+      'd051aa72ce08b60fd587a74a5146bf88')    export PSL_DCP_TYPE="N250S OUTDATED";;
+      *)                                     export PSL_DCP_TYPE="UNKNOWN";;
+    esac
+  fi
+
+  echo "$PSL_DCP_TYPE"
+
 else
-    exit
+  echo "Missing parameters for "`basename $0`
 fi
-
-if [ "$FPGACARD" == "N250SP" ]; then
-  export PSL_DCP_TYPE=$FPGACARD
-else
-  PSL_MD5=`md5sum $PSL_DCP | cut -d " " -f 1`
-
-  case $PSL_MD5 in
-    '5bf24f90f52e6959e8e6082245a2ac3c')    export PSL_DCP_TYPE="N250S";;
-    '3a2d162828aed3cb271d1151be9bfdde')    export PSL_DCP_TYPE="N250S";; # with reset fix 20171220
-    'd7196d64990594f6c267aa8192a41573')    export PSL_DCP_TYPE="N250S";; # with reset fix 20180212 + vivado 2017.4
-    '1b1526c0d3cb61815c886f83d3b4f202')    export PSL_DCP_TYPE="ADKU3";;    
-    'f920e532c7dfea8aa7c0f90db5b54bff')    export PSL_DCP_TYPE="ADKU3";; # with reset fix 20171220
-    '51b64ad40a3dc54ec855d7d7dfef0896')    export PSL_DCP_TYPE="ADKU3";; # rblack_PSLrev6_v174_20170122_vsec400
-    '3fa538efab1bc3e3fabe06477445d314')    export PSL_DCP_TYPE="S121B";; 
-    '8602200acb12d2de68c2a8a95735571a')    export PSL_DCP_TYPE="S121B";;
-    '400d13185ce03f38776d672690618b2e')    export PSL_DCP_TYPE="S121B";; # psl233_viv17.4_vsec400h_Feb23
-    'd051aa72ce08b60fd587a74a5146bf88')    export PSL_DCP_TYPE="N250S OUTDATED";;    
-    *)                                     export PSL_DCP_TYPE="UNKNOWN";;
-  esac
-fi
-
-echo "$PSL_DCP_TYPE"

--- a/snap_env
+++ b/snap_env
@@ -101,8 +101,7 @@ while [ -z "$SETUP_DONE" ]; do
       echo "#export PSL4N250SP_ROOT=" >> $snap_env_sh
     fi
     if [ -z "$PSL4N250SP_ROOT" ]; then
-      SETUP_EMPTY="$SETUP_EMPTY\n  PSL4N250S_ROOT"
-      SETUP_WARNING="$SETUP_WARNING\n### WARNING ### The environment variable PSL4N250SP_ROOT must point to the directory containing the PSL IP together with N250SP card support."
+      SETUP_INFO="$SETUP_INFO\n### INFO ### For image build the environment variable PSL4N250SP_ROOT must point to the directory containing the PSL IP together with N250SP card support."
     fi
   ####### checking path to PSL design checkpoint
   # Note: CLOUD_USER_FLOW is defined via snap_config


### PR DESCRIPTION
Allow for model build with 'illegal' PSL_DCP and (in case of N250SP) w/o PSL4N250SP_ROOT
Fast fail for image build in case of  'illegal' PSL_DCP or missing PSL4N250SP_ROOT