### PR TITLE
Correct bitstream parameters for N250S+

### DIFF
--- a/hardware/setup/flash_mcs.tcl
+++ b/hardware/setup/flash_mcs.tcl
@@ -35,12 +35,18 @@ switch $fpgacard {
         }
   S121B { set flashdevice mt28gu01gaax1e-bpi-x16
           set fpgapartnum xcku115
-          #FIXME? set rs_pins	{26:25}
+          set rs_pins	{26:25}
         }
   AD8K5 { set flashdevice mt28gu01gaax1e-bpi-x16
 	  set fpgapartnum xcku115
+          # CHECK User manual specifies rs_pins 25:24 
+          # despite the larger FPGA and user_addr 0x02000000
         }
-  N250SP { set flashdevice mt28ew01ga-bpi-x16
+  N250SP {
+          # old N250S+ config flash - serial 7105xxx
+          #   set flashdevice mt28gu01gaax1e-bpi-x16
+          # new N250S+ config flash - serial 7109xxx  
+          set flashdevice mt28ew01ga-bpi-x16
           set fpgapartnum xcku15p
           set rs_pins	{26:25}
         }
@@ -68,6 +74,8 @@ if { $argc == 2 } {
 }
 puts "Connecting to hardware target $hwtarget: [lindex [get_hw_targets] $hwtarget] "
 open_hw_target [lindex [get_hw_targets] $hwtarget]
+current_hw_device [lindex [get_hw_devices] 0]
+refresh_hw_device -update_hw_probes false [lindex [get_hw_devices] 0]
 
 # Hardware configuration
 create_hw_cfgmem -hw_device [lindex [get_hw_devices] 0] -mem_dev [lindex [get_cfgmem_parts $flashdevice] 0]
@@ -88,7 +96,9 @@ set_property PROGRAM.CFG_PROGRAM 1 $fpga_cfgmem
 set_property PROGRAM.VERIFY 1 $fpga_cfgmem
 set_property PROGRAM.CHECKSUM 0 $fpga_cfgmem
 startgroup
-if {![string equal [get_property PROGRAM.HW_CFGMEM_TYPE $fpgadevice ] [get_property MEM_TYPE [get_property CFGMEM_PART $fpga_cfgmem]]] } { create_hw_bitstream -hw_device $fpgadevice [get_property PROGRAM.HW_CFGMEM_BITFILE $fpgadevice ]; program_hw_devices $fpgadevice ; };
+if {![string equal [get_property PROGRAM.HW_CFGMEM_TYPE $fpgadevice ] [get_property MEM_TYPE [get_property CFGMEM_PART $fpga_cfgmem]]] } { 
+  create_hw_bitstream -hw_device $fpgadevice [get_property PROGRAM.HW_CFGMEM_BITFILE $fpgadevice ]
+  program_hw_devices $fpgadevice
+}
 program_hw_cfgmem -hw_cfgmem $fpga_cfgmem
-
 

--- a/hardware/setup/snap_bitstream_post.tcl
+++ b/hardware/setup/snap_bitstream_post.tcl
@@ -19,6 +19,5 @@
 set root_dir   $::env(SNAP_ROOT)/hardware
 
 # Max. size is 64MB for N250S and ADKU3, 128MB for S121B and N250SP. Bin file size will match the device, so -size is not relevant here.
-write_cfgmem -format bin -loadbit "up 0x0 $root_dir/viv_project/framework.runs/impl_1/psl_fpga.bit" -file $root_dir/viv_project/framework.runs/impl_1/psl_fpga -size 128 -interface  BPIx16 -force
-
+write_cfgmem -force -format bin -size 128 -interface BPIx16 -loadbit "up 0x0 $root_dir/viv_project/framework.runs/impl_1/psl_fpga.bit" $root_dir/viv_project/framework.runs/impl_1/psl_fpga
 

--- a/hardware/setup/snap_bitstream_post.tcl
+++ b/hardware/setup/snap_bitstream_post.tcl
@@ -18,5 +18,7 @@
 
 set root_dir   $::env(SNAP_ROOT)/hardware
 
+# Max. size is 64MB for N250S and ADKU3, 128MB for S121B and N250SP. Bin file size will match the device, so -size is not relevant here.
 write_cfgmem -format bin -loadbit "up 0x0 $root_dir/viv_project/framework.runs/impl_1/psl_fpga.bit" -file $root_dir/viv_project/framework.runs/impl_1/psl_fpga -size 128 -interface  BPIx16 -force
+
 

--- a/hardware/setup/snap_bitstream_pre.tcl
+++ b/hardware/setup/snap_bitstream_pre.tcl
@@ -18,21 +18,27 @@
 
 set factory_image [string toupper $::env(FACTORY_IMAGE)]
 
-set_property BITSTREAM.GENERAL.COMPRESS {TRUE} [ current_design ]
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
 set_property BITSTREAM.CONFIG.EXTMASTERCCLK_EN {DIV-4} [current_design]
-set_property CONFIG_MODE {BPI16} [current_design]
+set_property CONFIG_MODE BPI16 [current_design]
+set_property BITSTREAM.CONFIG.BPI_SYNC_MODE DISABLE [current_design]		# default disable
 set_property BITSTREAM.CONFIG.BPI_1ST_READ_CYCLE 4 [current_design]
 set_property BITSTREAM.CONFIG.BPI_PAGE_SIZE 8 [current_design]
 
+set_property BITSTREAM.CONFIG.UNUSEDPIN Pullnone [current_design]		# default pulldown, doesn't load at power-on!
+set_property BITSTREAM.CONFIG.OVERTEMPSHUTDOWN Enable [current_design]		# default disable
+set_property CONFIG_VOLTAGE 1.8 [current_design]
+set_property BITSTREAM.CONFIG.PERSIST NO [current_design] 			# default NO anyhow
 
-#FIXME? xapp1246/xapp1296: These settings may not be needed for SNAP
-set_property BITSTREAM.CONFIG.CONFIGFALLBACK ENABLE [current_design]		# default enable
-set_property BITSTREAM.CONFIG.TIMER_CFG 0XC0080000 [current_design]
+# xapp1246/xapp1296/ug908: These settings may not be needed for SNAP
+# set_property BITSTREAM.CONFIG.CONFIGFALLBACK ENABLE [current_design]		# default enable
+set_property BITSTREAM.CONFIG.TIMER_CFG 0XFFFFFFFF [current_design]		# no watchdog
 
-# The factory bitstream has the above properties with one addition:
+# The factory bitstream has the above properties plus:
 if { $factory_image == "TRUE" } {
-  #FIXME? xapp1246/xapp1296: These settings are not needed for SNAP
-  set_property BITSTREAM.CONFIG.NEXT_CONFIG_ADDR 0X01000000 [current_design]	# default is 0x0
+  #xapp1246/xapp1296: These settings are not needed for SNAP. 
+  #FIXME remove when testing was successful
+  # set_property BITSTREAM.CONFIG.NEXT_CONFIG_ADDR 0X01000000 [current_design]	# default is 0x0
   set_property BITSTREAM.CONFIG.REVISIONSELECT_TRISTATE ENABLE [current_design] # default enable
   set_property BITSTREAM.CONFIG.REVISIONSELECT 01 [current_design] 		# default is 00
 }

--- a/hardware/setup/snap_bitstream_pre.tcl
+++ b/hardware/setup/snap_bitstream_pre.tcl
@@ -24,13 +24,15 @@ set_property CONFIG_MODE {BPI16} [current_design]
 set_property BITSTREAM.CONFIG.BPI_1ST_READ_CYCLE 4 [current_design]
 set_property BITSTREAM.CONFIG.BPI_PAGE_SIZE 8 [current_design]
 
-#FIXME? xapp1246/xapp1296: These settings are not needed for SNAP
-#FIXME? set_property BITSTREAM.CONFIG.CONFIGFALLBACK ENABLE [current_design]		# default enable
-#FIXME? set_property BITSTREAM.CONFIG.NEXT_CONFIG_ADDR 0X01000000 [current_design]	# default is 0x0
-#FIXME? set_property BITSTREAM.CONFIG.REVISIONSELECT_TRISTATE ENABLE [current_design] 	# default enable
-#FIXME? set_property BITSTREAM.CONFIG.REVISIONSELECT 01 [current_design] 		# default is 00
+
+#FIXME? xapp1246/xapp1296: These settings may not be needed for SNAP
+set_property BITSTREAM.CONFIG.CONFIGFALLBACK ENABLE [current_design]		# default enable
+set_property BITSTREAM.CONFIG.TIMER_CFG 0XC0080000 [current_design]
 
 # The factory bitstream has the above properties with one addition:
 if { $factory_image == "TRUE" } {
-  set_property BITSTREAM.CONFIG.TIMER_CFG 0XFFFFFFFF [current_design]
+  #FIXME? xapp1246/xapp1296: These settings are not needed for SNAP
+  set_property BITSTREAM.CONFIG.NEXT_CONFIG_ADDR 0X01000000 [current_design]	# default is 0x0
+  set_property BITSTREAM.CONFIG.REVISIONSELECT_TRISTATE ENABLE [current_design] # default enable
+  set_property BITSTREAM.CONFIG.REVISIONSELECT 01 [current_design] 		# default is 00
 }

--- a/hardware/setup/snap_bitstream_pre.tcl
+++ b/hardware/setup/snap_bitstream_pre.tcl
@@ -21,25 +21,25 @@ set factory_image [string toupper $::env(FACTORY_IMAGE)]
 set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
 set_property BITSTREAM.CONFIG.EXTMASTERCCLK_EN {DIV-4} [current_design]
 set_property CONFIG_MODE BPI16 [current_design]
-set_property BITSTREAM.CONFIG.BPI_SYNC_MODE DISABLE [current_design]		# default disable
+set_property BITSTREAM.CONFIG.BPI_SYNC_MODE DISABLE [current_design]		;# default disable
 set_property BITSTREAM.CONFIG.BPI_1ST_READ_CYCLE 4 [current_design]
 set_property BITSTREAM.CONFIG.BPI_PAGE_SIZE 8 [current_design]
 
-set_property BITSTREAM.CONFIG.UNUSEDPIN Pullnone [current_design]		# default pulldown, doesn't load at power-on!
-set_property BITSTREAM.CONFIG.OVERTEMPSHUTDOWN Enable [current_design]		# default disable
+set_property BITSTREAM.CONFIG.UNUSEDPIN Pullnone [current_design]		;# default pulldown, doesn't load at power-on!
+set_property BITSTREAM.CONFIG.OVERTEMPSHUTDOWN Enable [current_design]		;# default disable
 set_property CFGBVS GND [ current_design ]
 set_property CONFIG_VOLTAGE 1.8 [current_design]
-set_property BITSTREAM.CONFIG.PERSIST NO [current_design] 			# default NO anyhow
+set_property BITSTREAM.CONFIG.PERSIST NO [current_design] 			;# default NO anyhow
 
 # xapp1246/xapp1296/ug908: These settings may not be needed for SNAP
-# set_property BITSTREAM.CONFIG.CONFIGFALLBACK ENABLE [current_design]		# default enable
-set_property BITSTREAM.CONFIG.TIMER_CFG 0XFFFFFFFF [current_design]		# no watchdog
+# set_property BITSTREAM.CONFIG.CONFIGFALLBACK ENABLE [current_design]		;# default enable
+set_property BITSTREAM.CONFIG.TIMER_CFG 0XFFFFFFFF [current_design]		;# no watchdog
 
 # The factory bitstream has the above properties plus:
 if { $factory_image == "TRUE" } {
   #xapp1246/xapp1296: These settings are not needed for SNAP. 
   #FIXME remove when testing was successful
-  # set_property BITSTREAM.CONFIG.NEXT_CONFIG_ADDR 0X01000000 [current_design]	# default is 0x0
-  set_property BITSTREAM.CONFIG.REVISIONSELECT_TRISTATE ENABLE [current_design] # default enable
-  set_property BITSTREAM.CONFIG.REVISIONSELECT 01 [current_design] 		# default is 00
+  # set_property BITSTREAM.CONFIG.NEXT_CONFIG_ADDR 0X01000000 [current_design]	;# default is 0x0
+  set_property BITSTREAM.CONFIG.REVISIONSELECT_TRISTATE ENABLE [current_design] ;# default enable
+  set_property BITSTREAM.CONFIG.REVISIONSELECT 01 [current_design] 		;# default is 00
 }

--- a/hardware/setup/snap_bitstream_pre.tcl
+++ b/hardware/setup/snap_bitstream_pre.tcl
@@ -27,6 +27,7 @@ set_property BITSTREAM.CONFIG.BPI_PAGE_SIZE 8 [current_design]
 
 set_property BITSTREAM.CONFIG.UNUSEDPIN Pullnone [current_design]		# default pulldown, doesn't load at power-on!
 set_property BITSTREAM.CONFIG.OVERTEMPSHUTDOWN Enable [current_design]		# default disable
+set_property CFGBVS GND [ current_design ]
 set_property CONFIG_VOLTAGE 1.8 [current_design]
 set_property BITSTREAM.CONFIG.PERSIST NO [current_design] 			# default NO anyhow
 

--- a/hardware/setup/snap_build.tcl
+++ b/hardware/setup/snap_build.tcl
@@ -286,7 +286,7 @@ if { [catch "$command > $logfile" errMsg] } {
   puts [format "%-*s %-*s %-*s %-*s"  $widthCol1 "" $widthCol2 "" $widthCol3 "       please check $logfile" $widthCol4 "" ]
   exit 42
 } else {
-  write_cfgmem -format bin -loadbit "up 0x0 ./Images/$IMAGE_NAME.bit" -file ./Images/$IMAGE_NAME  -size 128 -interface  BPIx16 -force >> $logfile
+  write_cfgmem -force -format bin -size 128 -interface  BPIx16 -loadbit "up 0x0 ./Images/$IMAGE_NAME.bit" ./Images/$IMAGE_NAME >> $logfile
 }
 
 

--- a/software/tools/snap_maint.c
+++ b/software/tools/snap_maint.c
@@ -182,7 +182,7 @@ static void snap_version(void *handle)
 		VERBOSE1("enabled");
 	else    VERBOSE1("disabled");
         snap_card_ioctl(handle, GET_SDRAM_SIZE, (unsigned long)&ioctl_data);
-        VERBOSE1(", %d MB SRAM available.\n", (int)ioctl_data);
+        VERBOSE1(", %d MB DRAM available.\n", (int)ioctl_data);
 
 	reg = snap_read64(handle, SNAP_M_CTX, SNAP_M_IVR);
 	VERBOSE1("SNAP FPGA Release: v%d.%d.%d Distance: %d GIT: 0x%8.8x\n",


### PR DESCRIPTION
... and some more comments.
TBD: the optimal bitstream generation parameters provided by the manufacturers differ from card to card, e.g. the synchronous mode DISABLED or TYPE1, or configuration clock divider (DIV-4, DIV-1)
