### PR TITLE
snap_find_card_update

### DIFF
--- a/software/tools/snap_find_card
+++ b/software/tools/snap_find_card
@@ -83,7 +83,7 @@ function detect_snap_cards() {
 				echo " PSL Revision is                                                : ${psl_revision_hex}"
                                 echo -e " Device ID    is                                                : ${check_dev}"
                                 echo -e " Sub device   is                                                : ${check_sub}"
-				echo -e " Image loaded is                                                : ${image_loaded}"
+				echo -e " Image loaded is self defined as                                : ${image_loaded}"
 				echo -e " Next image to be loaded at next reset (load_image_on_perst) is : ${load_image_on_perst}"
 			else
 				echo -n "${card} "


### PR DESCRIPTION
Since the bit stream contains the information, it can be misleading not to mention it.
Signed-off-by: Alexandre Castellane alexandre.castellane@fr.ibm.com