### PR TITLE
Change factory bit to a pre-set register

### DIFF
--- a/hardware/doc/Bitstream_flashing.md
+++ b/hardware/doc/Bitstream_flashing.md
@@ -42,7 +42,7 @@ Erasing Flash
 # How to build the factory ("golden") bitstream image
 
 Normally there is no need to update the factory bitstream, because its main purpose is to allow to program the user partition of the flash safely again. It may also be used to test if the card is still functioning correctly with a known good bitstream.
-To build a factory bitstream, mark the "Create Factory Image" option in the configurator `make snap_config` and proceed with the image build as usual.
+To build a factory bitstream in addition to the user bitstream, mark the "Also create a factory image" option in the configurator `make snap_config` and proceed with the image build as usual.
 
 The output bitstream file names will have `_FACTORY` appended.  
 
@@ -53,26 +53,14 @@ Connect the Platform Cable with the card as described in the card's reference ma
 
 ## 1. Programming the flash device with a .mcs file 
 
-* Build user bitstream *.bit file
-* Build factory bitstream *_FACTORY.bit file
-* Use [hardware/setup/build_mcs.tcl](../setup/build_mcs.tcl) to build the MCS file from the bit file
+* Build the user and factory bitstream (*.bit and *_FACTORY.bit) files as described above
+* Use [hardware/setup/build_mcs.tcl](../setup/build_mcs.tcl) to compile the MCS file from the bit files
   ### Example:
   ```bash
   echo "ENABLE_FACTORY=y" >> .snap_config
   make -s oldconfig
   make image
-
-  # Save the user image from the following implicit "make clean"
-  mv ./hardware/build/Images/*.bi? .
-
-  # Build the USER bitstream.
-  echo "ENABLE_FACTORY=n" >> .snap_config
-  make -s oldconfig
-  make image
-
-  # Restore the user image
-  mv ./*.bi? ./hardware/build/Images/
-
+  
   # Compile the MCS file from FACTORY and USER bitstreams
   factory_bitstream=`ls -t ./hardware/build/Images/fw_*[0-9]_FACTORY.bit | head -n1`
   echo "Factory bitstream=$factory_bitstream"
@@ -80,6 +68,11 @@ Connect the Platform Cable with the card as described in the card's reference ma
   echo "User bitstream=$user_bitstream"
   source .snap_config.sh
   ./hardware/setup/build_mcs.tcl $factory_bitstream $user_bitstream ${factory_bitstream%.bit}.mcs
+  
+  # Optional: restore the default setting that doesn't build the factory image
+  # Attention: this will also delete the bitstreams created before!
+  # echo "ENABLE_FACTORY=n" >> .snap_config
+  # make -s oldconfig
   ```
 * Program the flash using [hardware/setup/flash_mcs.tcl](../setup/flash_mcs.tcl)  
   Programming the flash will take several minutes, please be patient.

--- a/hardware/hdl/core/psl_fpga_ad8k5.vhd_source
+++ b/hardware/hdl/core/psl_fpga_ad8k5.vhd_source
@@ -391,10 +391,13 @@ Signal ha0_response: std_logic_vector(0 to 7);  -- apresp
 Signal ha0_rtag: std_logic_vector(0 to 7);  -- acctag
 Signal ha0_rtagpar: std_logic;  -- bool
 Signal ha0_rvalid: std_logic;  -- bool
-Signal gold_factory: std_logic;
-Signal pci_user_reset: std_logic;
-Signal pci_clock_125MHz: std_logic;
 
+SIGNAL user_image_q        : std_logic := '1';  --set to 1 to indicate images meant for user location. set to 0 to indicate factory image. 
+ATTRIBUTE dont_touch       : string;
+ATTRIBUTE dont_touch of user_image_q: SIGNAL IS "true";
+SIGNAL gold_factory        : std_logic;
+SIGNAL pci_user_reset      : std_logic;
+SIGNAL pci_clock_125MHz    : std_logic;
 -- clk #ifdef CONFIG_ENABLE_DDRI
 -- clk   SIGNAL refclk_sdram              : STD_LOGIC;
 -- clk #endif
@@ -494,12 +497,15 @@ begin
          pci_clock_125MHz     => pci_clock_125MHz
     );
 
-#ifdef CONFIG_ENABLE_FACTORY
-    gold_factory <= '0'; --set to 1 to indicate images meant for user location. set to 0 to indicate factory image.
-#else
-    gold_factory <= '1'; --set to 1 to indicate images meant for user location. set to 0 to indicate factory image.
-#endif
+    PROCESS (ha0_pclock)
+    BEGIN
+      IF(RISING_EDGE(ha0_pclock)) THEN
+        user_image_q <= user_image_q;
+      END IF;
+    END PROCESS;
 
+    gold_factory <= user_image_q;
+     
     b: base_img
      PORT MAP (
          pci_pi_nperst0 => pci_pi_nperst0,

--- a/hardware/hdl/core/psl_fpga_adku3.vhd_source
+++ b/hardware/hdl/core/psl_fpga_adku3.vhd_source
@@ -393,6 +393,9 @@ Signal ha0_rvalid: std_logic;  -- bool
 Signal gold_factory: std_logic;
 Signal pci_user_reset: std_logic;
 Signal pci_clock_125MHz: std_logic;
+SIGNAL user_image_q: std_logic := '1'; 
+ATTRIBUTE dont_touch: string;
+ATTRIBUTE dont_touch of user_image_q: SIGNAL IS "true";
 
 begin
 
@@ -482,11 +485,14 @@ begin
          pci_clock_125MHz     => pci_clock_125MHz
     );
 
-#ifdef CONFIG_ENABLE_FACTORY
-    gold_factory <= '0'; --set to 1 to indicate images meant for user location. set to 0 to indicate factory image.
-#else
-    gold_factory <= '1'; --set to 1 to indicate images meant for user location. set to 0 to indicate factory image.
-#endif
+    PROCESS (ha0_pclock)
+    BEGIN
+      IF(RISING_EDGE(ha0_pclock)) THEN
+        user_image_q <= user_image_q;
+      END IF;
+    END PROCESS;
+
+    gold_factory <= user_image_q; 
      
     b: base_img
      PORT MAP (

--- a/hardware/hdl/core/psl_fpga_adku3.vhd_source
+++ b/hardware/hdl/core/psl_fpga_adku3.vhd_source
@@ -390,12 +390,13 @@ Signal ha0_response: std_logic_vector(0 to 7);  -- apresp
 Signal ha0_rtag: std_logic_vector(0 to 7);  -- acctag
 Signal ha0_rtagpar: std_logic;  -- bool
 Signal ha0_rvalid: std_logic;  -- bool
-Signal gold_factory: std_logic;
-Signal pci_user_reset: std_logic;
-Signal pci_clock_125MHz: std_logic;
-SIGNAL user_image_q: std_logic := '1';
-ATTRIBUTE dont_touch: string;
+
+SIGNAL user_image_q        : std_logic := '1';  --set to 1 to indicate images meant for user location. set to 0 to indicate factory image. 
+ATTRIBUTE dont_touch       : string;
 ATTRIBUTE dont_touch of user_image_q: SIGNAL IS "true";
+SIGNAL gold_factory        : std_logic;
+SIGNAL pci_user_reset      : std_logic;
+SIGNAL pci_clock_125MHz    : std_logic;
 
 begin
 

--- a/hardware/hdl/core/psl_fpga_adku3.vhd_source
+++ b/hardware/hdl/core/psl_fpga_adku3.vhd_source
@@ -393,7 +393,7 @@ Signal ha0_rvalid: std_logic;  -- bool
 Signal gold_factory: std_logic;
 Signal pci_user_reset: std_logic;
 Signal pci_clock_125MHz: std_logic;
-SIGNAL user_image_q: std_logic := '1'; 
+SIGNAL user_image_q: std_logic := '1';
 ATTRIBUTE dont_touch: string;
 ATTRIBUTE dont_touch of user_image_q: SIGNAL IS "true";
 
@@ -492,7 +492,7 @@ begin
       END IF;
     END PROCESS;
 
-    gold_factory <= user_image_q; 
+    gold_factory <= user_image_q;
      
     b: base_img
      PORT MAP (

--- a/hardware/hdl/core/psl_fpga_n250s.vhd_source
+++ b/hardware/hdl/core/psl_fpga_n250s.vhd_source
@@ -467,12 +467,13 @@ SIGNAL ha0_response: std_logic_vector(0 TO 7);  -- apresp
 SIGNAL ha0_rtag: std_logic_vector(0 TO 7);  -- acctag
 SIGNAL ha0_rtagpar: std_logic;  -- bool
 SIGNAL ha0_rvalid: std_logic;  -- bool
-SIGNAL gold_factory: std_logic;
-SIGNAL user_image_q: std_logic := '1';
-ATTRIBUTE dont_touch: string;
+
+SIGNAL user_image_q        : std_logic := '1';  --set to 1 to indicate images meant for user location. set to 0 to indicate factory image. 
+ATTRIBUTE dont_touch       : string;
 ATTRIBUTE dont_touch of user_image_q: SIGNAL IS "true";
-SIGNAL pci_user_reset: std_logic;
-SIGNAL pci_clock_125MHz: std_logic;
+SIGNAL gold_factory        : std_logic;
+SIGNAL pci_user_reset      : std_logic;
+SIGNAL pci_clock_125MHz    : std_logic;
 SIGNAL led_red: std_logic_vector(0 TO 1);
 SIGNAL led_green: std_logic_vector(0 TO 1);
 SIGNAL led_blue: std_logic_vector(0 TO 1);

--- a/hardware/hdl/core/psl_fpga_n250s.vhd_source
+++ b/hardware/hdl/core/psl_fpga_n250s.vhd_source
@@ -468,6 +468,9 @@ SIGNAL ha0_rtag: std_logic_vector(0 TO 7);  -- acctag
 SIGNAL ha0_rtagpar: std_logic;  -- bool
 SIGNAL ha0_rvalid: std_logic;  -- bool
 SIGNAL gold_factory: std_logic;
+SIGNAL user_image_q: std_logic := '1';
+ATTRIBUTE dont_touch: string;
+ATTRIBUTE dont_touch of user_image_q: SIGNAL IS "true";
 SIGNAL pci_user_reset: std_logic;
 SIGNAL pci_clock_125MHz: std_logic;
 SIGNAL led_red: std_logic_vector(0 TO 1);
@@ -655,11 +658,14 @@ BEGIN
       pci_clock_125MHz                  => pci_clock_125MHz
     );
 
-#ifdef CONFIG_ENABLE_FACTORY
-    gold_factory <= '0'; --set to 1 to indicate images meant for user location. set to 0 to indicate factory image.
-#else
-    gold_factory <= '1'; --set to 1 to indicate images meant for user location. set to 0 to indicate factory image.
-#endif
+    PROCESS (ha0_pclock)
+    BEGIN
+      IF(RISING_EDGE(ha0_pclock)) THEN
+        user_image_q <= user_image_q;
+      END IF;
+    END PROCESS;
+
+    gold_factory <= user_image_q;
 
     -- led controls
     led_red <= "11";

--- a/hardware/hdl/core/psl_fpga_n250sp.vhd_source
+++ b/hardware/hdl/core/psl_fpga_n250sp.vhd_source
@@ -581,9 +581,13 @@ SIGNAL hd0_cpl_byte_count  : std_logic_vector(0 to 9)   ;
 SIGNAL hd0_cpl_size        : std_logic_vector(0 to 9)   ;
 SIGNAL hd0_cpl_data        : std_logic_vector(0 to 1023);
 
+SIGNAL user_image_q        : std_logic := '1';
+ATTRIBUTE dont_touch       : string;
+ATTRIBUTE dont_touch of user_image_q: SIGNAL IS "true";
 SIGNAL gold_factory        : std_logic;
 SIGNAL pci_user_reset      : std_logic;
 SIGNAL pci_clock_125MHz    : std_logic;
+
 #ifdef CONFIG_ENABLE_NVME
 -- NVME Reset Logic
 SIGNAL nvme_reset_cnt_q    : std_logic_vector(15 DOWNTO 0) := (OTHERS => '1');
@@ -813,12 +817,28 @@ BEGIN
       hd1_cpl_data                      => (others => '0')  --efes1024(1023 downto 0)
     );
 
+<<<<<<< HEAD
 
 #ifdef CONFIG_ENABLE_FACTORY
     gold_factory <= '0'; --set to 1 to indicate images meant for user location. set to 0 to indicate factory image.
 #else
     gold_factory <= '1'; --set to 1 to indicate images meant for user location. set to 0 to indicate factory image.
 #endif
+=======
+    PROCESS (ha0_pclock)
+    BEGIN
+      IF(RISING_EDGE(ha0_pclock)) THEN
+        user_image_q <= user_image_q;
+      END IF;
+    END PROCESS;
+
+    gold_factory <= user_image_q;
+
+    -- led controls
+--    led_red <= "11";
+--    led_green <= "11";
+--    led_blue <= "11";
+>>>>>>> Added factory bit register to other targets. Built w/ N250S
 
   psl: psl4n250sp
     PORT MAP (

--- a/hardware/hdl/core/psl_fpga_n250sp.vhd_source
+++ b/hardware/hdl/core/psl_fpga_n250sp.vhd_source
@@ -581,7 +581,7 @@ SIGNAL hd0_cpl_byte_count  : std_logic_vector(0 to 9)   ;
 SIGNAL hd0_cpl_size        : std_logic_vector(0 to 9)   ;
 SIGNAL hd0_cpl_data        : std_logic_vector(0 to 1023);
 
-SIGNAL user_image_q        : std_logic := '1';
+SIGNAL user_image_q        : std_logic := '1';  --set to 1 to indicate images meant for user location. set to 0 to indicate factory image. 
 ATTRIBUTE dont_touch       : string;
 ATTRIBUTE dont_touch of user_image_q: SIGNAL IS "true";
 SIGNAL gold_factory        : std_logic;
@@ -817,14 +817,6 @@ BEGIN
       hd1_cpl_data                      => (others => '0')  --efes1024(1023 downto 0)
     );
 
-<<<<<<< HEAD
-
-#ifdef CONFIG_ENABLE_FACTORY
-    gold_factory <= '0'; --set to 1 to indicate images meant for user location. set to 0 to indicate factory image.
-#else
-    gold_factory <= '1'; --set to 1 to indicate images meant for user location. set to 0 to indicate factory image.
-#endif
-=======
     PROCESS (ha0_pclock)
     BEGIN
       IF(RISING_EDGE(ha0_pclock)) THEN
@@ -833,12 +825,6 @@ BEGIN
     END PROCESS;
 
     gold_factory <= user_image_q;
-
-    -- led controls
---    led_red <= "11";
---    led_green <= "11";
---    led_blue <= "11";
->>>>>>> Added factory bit register to other targets. Built w/ N250S
 
   psl: psl4n250sp
     PORT MAP (

--- a/hardware/hdl/core/psl_fpga_s121b.vhd_source
+++ b/hardware/hdl/core/psl_fpga_s121b.vhd_source
@@ -390,6 +390,9 @@ Signal ha0_rtag: std_logic_vector(0 to 7);  -- acctag
 Signal ha0_rtagpar: std_logic;  -- bool
 Signal ha0_rvalid: std_logic;  -- bool
 Signal gold_factory: std_logic;
+SIGNAL user_image_q: std_logic := '1';
+ATTRIBUTE dont_touch: string;
+ATTRIBUTE dont_touch of user_image_q: SIGNAL IS "true";
 Signal pci_user_reset: std_logic;
 Signal pci_clock_125MHz: std_logic;
 
@@ -479,11 +482,14 @@ begin
          pci_clock_125MHz        => pci_clock_125MHz
     );
 
-#ifdef CONFIG_ENABLE_FACTORY
-    gold_factory <= '0'; --set to 1 to indicate images meant for user location. set to 0 to indicate factory image.
-#else
-    gold_factory <= '1'; --set to 1 to indicate images meant for user location. set to 0 to indicate factory image.
-#endif
+    PROCESS (ha0_pclock)
+    BEGIN
+      IF(RISING_EDGE(ha0_pclock)) THEN
+        user_image_q <= user_image_q;
+      END IF;
+    END PROCESS;
+
+    gold_factory <= user_image_q;
 
     b: base_img
      PORT MAP (

--- a/hardware/hdl/core/psl_fpga_s121b.vhd_source
+++ b/hardware/hdl/core/psl_fpga_s121b.vhd_source
@@ -389,12 +389,13 @@ Signal ha0_response: std_logic_vector(0 to 7);  -- apresp
 Signal ha0_rtag: std_logic_vector(0 to 7);  -- acctag
 Signal ha0_rtagpar: std_logic;  -- bool
 Signal ha0_rvalid: std_logic;  -- bool
-Signal gold_factory: std_logic;
-SIGNAL user_image_q: std_logic := '1';
-ATTRIBUTE dont_touch: string;
+
+SIGNAL user_image_q        : std_logic := '1';  --set to 1 to indicate images meant for user location. set to 0 to indicate factory image. 
+ATTRIBUTE dont_touch       : string;
 ATTRIBUTE dont_touch of user_image_q: SIGNAL IS "true";
-Signal pci_user_reset: std_logic;
-Signal pci_clock_125MHz: std_logic;
+SIGNAL gold_factory        : std_logic;
+SIGNAL pci_user_reset      : std_logic;
+SIGNAL pci_clock_125MHz    : std_logic;
 
 begin
 

--- a/hardware/setup/snap_bitstream_pre.tcl
+++ b/hardware/setup/snap_bitstream_pre.tcl
@@ -16,8 +16,6 @@
 #
 #-----------------------------------------------------------
 
-set factory_image [string toupper $::env(FACTORY_IMAGE)]
-
 set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
 set_property BITSTREAM.CONFIG.EXTMASTERCCLK_EN {DIV-4} [current_design]
 set_property CONFIG_MODE BPI16 [current_design]
@@ -32,14 +30,6 @@ set_property CONFIG_VOLTAGE 1.8 [current_design]
 set_property BITSTREAM.CONFIG.PERSIST NO [current_design] 			;# default NO anyhow
 
 # xapp1246/xapp1296/ug908: These settings may not be needed for SNAP
-# set_property BITSTREAM.CONFIG.CONFIGFALLBACK ENABLE [current_design]		;# default enable
+set_property BITSTREAM.CONFIG.CONFIGFALLBACK ENABLE [current_design]		;# default enable
 set_property BITSTREAM.CONFIG.TIMER_CFG 0XFFFFFFFF [current_design]		;# no watchdog
 
-# The factory bitstream has the above properties plus:
-if { $factory_image == "TRUE" } {
-  #xapp1246/xapp1296: These settings are not needed for SNAP. 
-  #FIXME remove when testing was successful
-  # set_property BITSTREAM.CONFIG.NEXT_CONFIG_ADDR 0X01000000 [current_design]	;# default is 0x0
-  set_property BITSTREAM.CONFIG.REVISIONSELECT_TRISTATE ENABLE [current_design] ;# default enable
-  set_property BITSTREAM.CONFIG.REVISIONSELECT 01 [current_design] 		;# default is 00
-}

--- a/hardware/setup/snap_build.tcl
+++ b/hardware/setup/snap_build.tcl
@@ -277,6 +277,11 @@ source $root_dir/setup/snap_bitstream_pre.tcl
 
 if { $factory_image == "TRUE" } {
   puts [format "%-*s %-*s %-*s %-*s"  $widthCol1 "" $widthCol2 "generating bitstreams" $widthCol3 "type: factory image" $widthCol4 "[clock format [clock seconds] -format {%T %a %b %d %Y}]"]
+  if { $fpgacard == "ADKU3" } { 
+    # Change psl_fpga factory bit
+    puts [format "%-*s %-*s %-*s %-*s"  $widthCol1 "" $widthCol2 "changing factory bit" $widthCol3 "type: factory image" $widthCol4 "[clock format [clock seconds] -format {%T %a %b %d %Y}]"]
+    set_property INIT 1'b0 [get_cells user_image_q_reg]
+  }
 } else {
   puts [format "%-*s %-*s %-*s %-*s"  $widthCol1 "" $widthCol2 "generating bitstreams" $widthCol3 "type: user image" $widthCol4 "[clock format [clock seconds] -format {%T %a %b %d %Y}]"]
 }

--- a/hardware/setup/snap_build.tcl
+++ b/hardware/setup/snap_build.tcl
@@ -277,11 +277,8 @@ source $root_dir/setup/snap_bitstream_pre.tcl
 
 if { $factory_image == "TRUE" } {
   puts [format "%-*s %-*s %-*s %-*s"  $widthCol1 "" $widthCol2 "generating bitstreams" $widthCol3 "type: factory image" $widthCol4 "[clock format [clock seconds] -format {%T %a %b %d %Y}]"]
-  if { $fpgacard == "ADKU3" } { 
     # Change psl_fpga factory bit
-    puts [format "%-*s %-*s %-*s %-*s"  $widthCol1 "" $widthCol2 "changing factory bit" $widthCol3 "type: factory image" $widthCol4 "[clock format [clock seconds] -format {%T %a %b %d %Y}]"]
     set_property INIT 1'b0 [get_cells user_image_q_reg]
-  }
 } else {
   puts [format "%-*s %-*s %-*s %-*s"  $widthCol1 "" $widthCol2 "generating bitstreams" $widthCol3 "type: user image" $widthCol4 "[clock format [clock seconds] -format {%T %a %b %d %Y}]"]
 }

--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -357,7 +357,7 @@ config ILA_DEBUG
         default "FALSE" if ! ENABLE_ILA
 
 config ENABLE_FACTORY
-        bool "Create Factory Image"
+        bool "Also create a factory image"
         help 
           Used to generate a specific image to be located into the factory area
           Default image is in the user area. 


### PR DESCRIPTION
Based on branch change_factory_bit by @kenhill 
Rebased, added remaining card and made implementation the same across cards
Integrated into snap_build and Kconfig
Updated bitstream parameters for user/factory image
Todo: more detailed testing of multiboot fallback on all cards with different failure scenarios (not part of this pull request