### PR TITLE
Updated create_ip.tcl

### DIFF
--- a/hardware/setup/create_ip.tcl
+++ b/hardware/setup/create_ip.tcl
@@ -280,7 +280,7 @@ if { $create_clock_conv == "TRUE" } {
 
 #create axi interconect
 if { $create_interconect == "TRUE" } {
-  puts "                        generating IP axi_interconect"
+  puts "                        generating IP axi_interconnect"
   create_ip -name axi_interconnect -vendor xilinx.com -library ip -version 1.7 -module_name axi_interconnect -dir $ip_dir  >> $log_file
   set_property -dict [list                                  \
                       CONFIG.NUM_SLAVE_PORTS {2}            \


### PR DESCRIPTION
typo : generating IP axi_interconnect
Signed-off-by: Alexandre Castellane alexandre.castellane@fr.ibm.com