### PR TITLE
Fix actions/hls.mk to get FPGACHIP automatically

### DIFF
--- a/actions/hls.mk
+++ b/actions/hls.mk
@@ -21,7 +21,7 @@
 #FPGACHIP    ?= xcku060-ffva1156-2-e
 CONFIG_FILE = $(SNAP_ROOT)/.snap_config
 ifneq ("$(wildcard $(CONFIG_FILE))","")
-  FPGACHIP = $(shell grep FPGACHIP $(SNAP_ROOT)/.snap_config | cut -d = -f 2)
+  FPGACHIP = $(shell grep FPGACHIP $(CONFIG_FILE) | cut -d = -f 2)
   $(info FPGACHIP is set to $(FPGACHIP).)
 endif
 

--- a/actions/hls.mk
+++ b/actions/hls.mk
@@ -18,7 +18,13 @@
 #   xcku060-ffva1156-2-e
 #   xc7vx690tffg1157-2
 #   xcku115-flva1517-2-e
-FPGACHIP    ?= xcku060-ffva1156-2-e
+#FPGACHIP    ?= xcku060-ffva1156-2-e
+CONFIG_FILE = $(SNAP_ROOT)/.snap_config
+ifneq ("$(wildcard $(CONFIG_FILE))","")
+  FPGACHIP = $(shell grep FPGACHIP $(SNAP_ROOT)/.snap_config | cut -d = -f 2)
+  $(info FPGACHIP is set to $(FPGACHIP).)
+endif
+
 PART_NUMBER ?= $(FPGACHIP)
 
 # The wrapper name must match a function in the HLS sources which is


### PR DESCRIPTION
Looking for FPGACHIP information from $SNAP_ROOT/.snap_config 

It works and targets to solve #735  and part of #731 

For the very first time people still have to run `make snap_config` and `make model`
But when tuning the HLS hw code, they can stay in $ACTION_ROOT/hw directory and `make`.  It can shorten the iteration time in developement.