### PR TITLE
Simplify snap env.sh use of variables

### DIFF
--- a/check_pslse.sh
+++ b/check_pslse.sh
@@ -25,4 +25,22 @@ echo "card=$FPGACARD version=$version branch=$branch PSLVER=$PSLVER"
 #  "RCXVUP") if [ $branch != "\* capi2" ];then echo "WARNING: PSLSE branch=$branch should be capi2";fi;;
 #  *)        if [ $version != "v3.1"    ];then echo "WARNING: PSLSE version=$version should be v3.1";fi;;
 #esac
+#### Checking if PSLSE was compiled with the same version than what the card requests
+if [ -e ".pslsecompiled" ]; then
+  RESP=`grep PSLVER_ .pslsecompiled`
+  if [ $RESP == "PSLVER_8" ] && [ $PSLVER == 9 ] ; then
+    echo "WARNING PSLSE compiled for P8 while P9 model asked => recompiling PSLSE"
+    make clean
+    echo "PSLVER_$PSLVER" > .pslsecompiled
+  fi
+  if [ $RESP == "PSLVER_9" ] && [ $PSLVER == 8 ]; then
+    echo "WARNING PSLSE compiled for P9 while P8 model asked => recompiling PSLSE"
+    make clean
+    echo "PSLVER_$PSLVER" > .pslsecompiled
+  fi
+else
+  echo "WARNING PSLSE compiled version unknown: creating .pslsecompiled file + recompiling"
+  make clean
+  echo "PSLVER_$PSLVER" >> .pslsecompiled
+fi
 cd -

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -89,7 +89,7 @@ PSL_DCP_TYPE=$(shell $(SNAP_HARDWARE_ROOT)/snap_check_psl "$(FPGACARD)" "$(PSL_D
 
 ifeq ($(PLATFORM),x86_64)
 
-.PHONY: all snap_config check_snap_settings check_simulator check_nvme prepare_project snap_preprocess_start snap_preprocess_execute snap_preprocess patch_version patch_NVMe action_hw create_project hw_project_start hw_project .hw_project_done config add_psl_dcp check_bsp image cloud_enable cloud_base cloud_action cloud_merge pslse software app model xsim irun nosim sim
+.PHONY: all snap_config check_snap_settings check_simulator check_nvme prepare_project snap_preprocess_start snap_preprocess_execute snap_preprocess patch_version patch_NVMe action_hw create_project hw_project_start hw_project .hw_project_done config add_psl_dcp check_bsp image cloud_enable cloud_base cloud_action cloud_merge pslse software app model xsim irun nosim sim clean
 
 all: model image
 
@@ -382,7 +382,7 @@ cloud_merge: allow_cloud_merge $(SNAP_BASE_DCP) $(SNAP_ACTION_DCP)
 pslse: prepare_logs
 	@echo -e "[COMPILE PSLSE ......] start `date +"%T %a %b %d %Y"`"
 	@$(SNAP_ROOT)/check_pslse.sh > $(LOGS_DIR)/compile_pslse.log 2>&1
-	@$(MAKE) -C $(PSLSE_ROOT) >> $(LOGS_DIR)/compile_pslse.log 2>&1; \
+	@$(MAKE) -C $(PSLSE_ROOT) clean all >> $(LOGS_DIR)/compile_pslse.log 2>&1; \
 	if [ $$? -ne 0 ]; then echo -e "                        Error: please look into $(LOGS_DIR)/compile_pslse.log"; exit -1; fi
 	@echo -e "[COMPILE PSLSE ......] done  `date +"%T %a %b %d %Y"`"
 

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -382,7 +382,7 @@ cloud_merge: allow_cloud_merge $(SNAP_BASE_DCP) $(SNAP_ACTION_DCP)
 pslse: prepare_logs
 	@echo -e "[COMPILE PSLSE ......] start `date +"%T %a %b %d %Y"`"
 	@$(SNAP_ROOT)/check_pslse.sh > $(LOGS_DIR)/compile_pslse.log 2>&1
-	@$(MAKE) -C $(PSLSE_ROOT) clean all >> $(LOGS_DIR)/compile_pslse.log 2>&1; \
+	@$(MAKE) -C $(PSLSE_ROOT) >> $(LOGS_DIR)/compile_pslse.log 2>&1; \
 	if [ $$? -ne 0 ]; then echo -e "                        Error: please look into $(LOGS_DIR)/compile_pslse.log"; exit -1; fi
 	@echo -e "[COMPILE PSLSE ......] done  `date +"%T %a %b %d %Y"`"
 

--- a/hardware/setup/create_framework.tcl
+++ b/hardware/setup/create_framework.tcl
@@ -265,7 +265,7 @@ if { ($capi_ver == "capi20") && [file exists $capi_bsp_dir/capi_bsp_wrap.xcix] }
   add_files -norecurse                  $capi_bsp_dir/capi_bsp_wrap.xcix -force >> $log_file
   export_ip_user_files -of_objects      [get_files capi_bsp_wrap.xci] -force >> $log_file
   set_property used_in_simulation false [get_files capi_bsp_wrap.xci] >> $log_file
-} elseif { $psl_dcp != "FALSE" } {
+} elseif { ($capi_ver == "capi10") && ($psl_dcp != "FALSE") } {
   puts "                        importing PSL design checkpoint"
   read_checkpoint -cell b $psl_dcp -strict >> $log_file
 }

--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -21,7 +21,7 @@ choice
                   storage. Uses Xilinx FPGA XCKU060.
 
         config ADKU3
-                bool "CAPI1.0:AlphaData KU3 with Ethernet, 8GB DDR3 SDRAM and Xilinx KU60 FPGA"
+                bool "CAPI1.0: AlphaData KU3 with Ethernet, 8GB DDR3 SDRAM and Xilinx KU60 FPGA"
                 select CAPI10
                 select DISABLE_NVME
                 help

--- a/snap_env
+++ b/snap_env
@@ -93,15 +93,16 @@ while [ -z "$SETUP_DONE" ]; do
   fi
 
   ####### checking default variables
-  RESP=`grep PSL_DCP $snap_env_sh`
-  if [ -z "$RESP" ]; then
-    echo "#For CAPI1.0 enabled cards" >> $snap_env_sh
-    echo "#export PSL_DCP= <path to b_route_design.dcp file>" >> $snap_env_sh
-  fi
-  RESP=`grep PSL9_IP_CORE $snap_env_sh`
-  if [ -z "$RESP" ]; then
-    echo "#For CAPI2.0 enabled cards" >> $snap_env_sh
-    echo "#export PSL9_IP_CORE= <path to ibm.com_CAPI_PSL9_WRAP2.00.zip file>" >> $snap_env_sh
+  if [ "$CAPI20" == "y" ]; then 
+    RESP=`grep PSL9_IP_CORE $snap_env_sh`
+    if [ -z "$RESP" ]; then
+      echo "export PSL9_IP_CORE= <for CAPI2.0 cards: path to ibm.com_CAPI_PSL9_WRAP2.00.zip file>" >> $snap_env_sh
+    fi
+  else
+    RESP=`grep PSL_DCP $snap_env_sh`
+    if [ -z "$RESP" ]; then
+      echo "export PSL_DCP= <for CAPI1.0 cards: path to b_route_design.dcp file>" >> $snap_env_sh
+    fi
   fi
 
   ####### checking PSL DCP setup
@@ -134,7 +135,7 @@ while [ -z "$SETUP_DONE" ]; do
   # Note: SIMULATOR is defined via snap_config
   if [ "$SIMULATOR" != "nosim" ]; then
     echo "=====Simulation setup: Setting up PSLSE version=========="
-    if [ "$FPGACARD" == "N250SP" ] || [ "$FPGACARD" == "RCXVUP" ]; then
+    if [ "$CAPI20" == "y" ]; then 
       PSLVER="9"
     else
       PSLVER="8"

--- a/snap_env
+++ b/snap_env
@@ -92,6 +92,17 @@ while [ -z "$SETUP_DONE" ]; do
     echo "Vivado version          is set to: `vivado -version|head -n1`"
   fi
 
+  ####### checking default variables
+  RESP=`grep PSL_DCP $snap_env_sh`
+  if [ -z "$RESP" ]; then
+    echo "#For CAPI1.0 enabled cards" >> $snap_env_sh
+    echo "#export PSL_DCP= <path to b_route_design.dcp file>" >> $snap_env_sh
+  fi
+  RESP=`grep PSL9_IP_CORE $snap_env_sh`
+  if [ -z "$RESP" ]; then
+    echo "#For CAPI2.0 enabled cards" >> $snap_env_sh
+    echo "#export PSL9_IP_CORE= <path to ibm.com_CAPI_PSL9_WRAP2.00.zip file>" >> $snap_env_sh
+  fi
 
   ####### checking PSL DCP setup
   if [ "$CAPI20" != "y" ]; then  # CAPI 2.0 setup does not depend on PSL DCP
@@ -102,10 +113,6 @@ while [ -z "$SETUP_DONE" ]; do
     else
       echo "=====Checking path to PSL design checkpoint============"
       echo "PSL_DCP                 is set to: \"$PSL_DCP\""
-      RESP=`grep PSL_DCP $snap_env_sh`
-      if [ -z "$RESP" ]; then
-        echo "#export PSL_DCP=" >> $snap_env_sh
-      fi
       if [ -e "$PSL_DCP" ]; then
         # checking card type for PSL design checkpoint
         PSL_DCP_TYPE=`$snapdir/hardware/snap_check_psl $FPGACARD $PSL_DCP`
@@ -127,9 +134,7 @@ while [ -z "$SETUP_DONE" ]; do
   # Note: SIMULATOR is defined via snap_config
   if [ "$SIMULATOR" != "nosim" ]; then
     echo "=====Simulation setup: Setting up PSLSE version=========="
-    if [ "$FPGACARD" == "N250SP" ]; then
-      PSLVER="9"
-    elif [ "$FPGACARD" == "RCXVUP" ]; then
+    if [ "$FPGACARD" == "N250SP" ] || [ "$FPGACARD" == "RCXVUP" ]; then
       PSLVER="9"
     else
       PSLVER="8"

--- a/snap_env
+++ b/snap_env
@@ -193,7 +193,7 @@ while [ -z "$SETUP_DONE" ]; do
     SETUP_INFO="$SETUP_INFO\n### INFO ### Kept ACTION_ROOT from previous configuration."
   else
     echo "Setting ACTION_ROOT            to: \"$AR\""
-    sed -i '#export[ ^]*ACTION_ROOT[ ^]*=# d' $snap_env_sh
+    sed -i '/export[ ^]*ACTION_ROOT[ ^]*=/ d' $snap_env_sh
     sed -i '1s#^#export ACTION_ROOT='$AR'\n#' $snap_env_sh
   fi
 

--- a/snap_env
+++ b/snap_env
@@ -142,7 +142,7 @@ while [ -z "$SETUP_DONE" ]; do
     fi
     echo "Setting PSLVER                 to: \"$PSLVER\""
     sed -i '/export[ ^]*PSLVER[ ^]*=/ d' $snap_env_sh
-    echo "export PSLVER=$PSLVER" >> $snap_env_sh
+    sed -i '1s/^/export PSLVER='$PSLVER'\n/' $snap_env_sh
     echo "=====Simulation setup: Checking path to PSLSE=========="
     echo "PSLSE_ROOT              is set to: \"$PSLSE_ROOT\""
     RESP=`grep PSLSE_ROOT $snap_env_sh`
@@ -193,8 +193,8 @@ while [ -z "$SETUP_DONE" ]; do
     SETUP_INFO="$SETUP_INFO\n### INFO ### Kept ACTION_ROOT from previous configuration."
   else
     echo "Setting ACTION_ROOT            to: \"$AR\""
-    sed -i '/export[ ^]*ACTION_ROOT[ ^]*=/ d' $snap_env_sh
-    echo "export ACTION_ROOT=$AR" >> $snap_env_sh
+    sed -i '#export[ ^]*ACTION_ROOT[ ^]*=# d' $snap_env_sh
+    sed -i '1s#^#export ACTION_ROOT='$AR'\n#' $snap_env_sh
   fi
 
   if [ -z "$AR" ] && [ "$ignore_action_root" != "y" ]; then
@@ -248,7 +248,7 @@ while [ -z "$SETUP_DONE" ]; do
   if [ -z "$TIMING_LABLIMIT" ]; then
     TIMING_LABLIMIT="$TIMING_LABLIMIT_DEFAULT"
     sed -i '/export[ ^]*TIMING_LABLIMIT[ ^]*=/ d' $snap_env_sh
-    echo "export TIMING_LABLIMIT=\"$TIMING_LABLIMIT_DEFAULT\"" >> $snap_env_sh
+    sed -i '1s/^/export TIMING_LABLIMIT="'$TIMING_LABLIMIT_DEFAULT'"\n/' $snap_env_sh
     SETUP_INFO="$SETUP_INFO\n### INFO ### Timing limit for FPGA image build got set to default value $TIMING_LABLIMIT_DEFAULT"
   fi
   echo "=====Timing limit for FPGA image build in ps============"

--- a/snap_env
+++ b/snap_env
@@ -135,7 +135,7 @@ while [ -z "$SETUP_DONE" ]; do
   # Note: SIMULATOR is defined via snap_config
   if [ "$SIMULATOR" != "nosim" ]; then
     echo "=====Simulation setup: Setting up PSLSE version=========="
-    if [ "$CAPI20" == "y" ]; then 
+    if [ "$CAPI20" == "y" ]; then
       PSLVER="9"
     else
       PSLVER="8"


### PR DESCRIPTION
PSL_DCP and PSL9_IP_CORE are inserted (commented) if no snap_env.sh file
PSL_DCP and PSL9_IP_CORE can be left set in both capi1.0 or 2.0 cards configuration
PSLSE is recompiled every time to prevent errors or prevent to have p8 and p9 compiled version (adds couple of secs only)
