### PR TITLE
Fix HLS action being re-compiled on every make

### DIFF
--- a/actions/hls.mk
+++ b/actions/hls.mk
@@ -21,7 +21,7 @@
 #FPGACHIP    ?= xcku060-ffva1156-2-e
 CONFIG_FILE = $(SNAP_ROOT)/.snap_config
 ifneq ("$(wildcard $(CONFIG_FILE))","")
-  FPGACHIP = $(shell grep FPGACHIP $(CONFIG_FILE) | cut -d = -f 2)
+  FPGACHIP = $(shell grep FPGACHIP $(CONFIG_FILE) | cut -d = -f 2 | tr -d '"')
 #  $(info FPGACHIP is set to $(FPGACHIP).)
 endif
 


### PR DESCRIPTION
Problem: Running make inside an HLS action's `hw` directory or making a snap target such as `model` or `image` always re-triggers an HLS compilation.

Cause: When generating a `snap_config`, the resulting FPGACHIP variable contains double quotes. These end up in the `syn_dir` variable in actions/hls.mk. However because the directory name on disk can't include these quotes, make tries to re-make this target every time it runs.

Solution: I've added another command to the FPGACHIP parser script, removing any double quote characters.