### PR TITLE
add factory address parameter to build_mcs

### DIFF
--- a/hardware/setup/build_mcs.tcl
+++ b/hardware/setup/build_mcs.tcl
@@ -23,6 +23,7 @@ if command -v vivado_lab > /dev/null ; then exec vivado_lab -nolog -nojournal -m
 set flash_interface $::env(FLASH_INTERFACE)
 set flash_size      $::env(FLASH_SIZE)
 set user_addr       $::env(FLASH_USERADDR)
+set factory_addr    $::env(FLASH_FACTORYADDR)
 
 if { $argc != 3 } {
   puts "Build an .mcs file for flashing a card from scratch"

--- a/hardware/setup/snap_bitstream_step.tcl
+++ b/hardware/setup/snap_bitstream_step.tcl
@@ -76,7 +76,7 @@ if { [catch "$command > $logfile" errMsg] } {
 
 # Also write the factory bitstream if it was selected
 if { $factory_image == "TRUE" } {
-  puts [format "%-*s %-*s %-*s %-*s"  $widthCol1 "" $widthCol2 "generating bitstreams" $widthCol3 "type: factory image" $widthCol4 "[clock format [clock seconds] -format {%T %a %b %d %Y}]"]
+  puts [format "%-*s%-*s%-*s%-*s"  $widthCol1 "" $widthCol2 "generating bitstreams" $widthCol3 "type: factory image" $widthCol4 "[clock format [clock seconds] -format {%T %a %b %d %Y}]"]
   # The factory bitstream has the properties from snap_bitstream_pre.tcl plus:
   #xapp1246/xapp1296: These settings are not needed for SNAP.
   #FIXME remove when testing was successful

--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -88,6 +88,11 @@ config FLASH_SIZE
         default 128 if S121B_BPIx16 || N250SP || AD8K5 || ADKU3
         default 64  if N250S
 
+#FLASH_FACTORYADDR: For all cards, factory address is 0x0;
+config FLASH_FACTORYADDR
+        string
+        default 0x00000000 
+
 #FLASH_USERADDR: For BPIx16, it is two-bytes address;
 #                For SPI, it is byte address.
 config FLASH_USERADDR
@@ -95,7 +100,6 @@ config FLASH_USERADDR
         default 0x01000000 if N250S || ADKU3
         default 0x02000000 if S121B_BPIx16 || AD8K5 || N250SP
         default 0x08000000 if S121B_SPIx4 || RCXVUP
-
 
 config S121B
         bool


### PR DESCRIPTION
In image building flow, print generating bitstreams for factory image format as user image format 

factory address disappeared at last change. Putting it back as a global parameter.
Add FLASH_FACTORYADDR as global parameter 
Add missing factory_addr parameter (add FLASH_FACTORYADDR)
Signed-off-by: Bruno MESNET <bruno.mesnet@fr.ibm.com>
