### PR TITLE
Fix CAPI BSP constraints

### DIFF
--- a/hardware/setup/create_framework.tcl
+++ b/hardware/setup/create_framework.tcl
@@ -278,9 +278,6 @@ puts "                        importing XDCs"
 if { $capi_ver == "capi20" } {
   puts "                        importing specific Board support XDCs"
   add_files -fileset constrs_1 -norecurse $root_dir/setup/$fpga_card/snap_$fpga_card.xdc >> $log_file
-  foreach xdc_file [glob -nocomplain -dir $root_dir/capi2-bsp/$fpga_card/xdc * ] {
-    add_files -fileset constrs_1 -norecurse $xdc_file >> $log_file
-  }
 }
 
 # DDR XDCs


### PR DESCRIPTION
The CAPI BSP constraints are no longer added explicitely.
As part of the capi_bsp_wrap IP they are automatically part of the project with property PROCESSING_ORDER set to EARLY.
@luyong6: This changes requires the PCIe clock pin issue for FX609 to be fixed in `hardware/setup/FX609/snap_FX609.xdc`