### PR TITLE
Remove xdc mistakenly used by S241 and FX609

### DIFF
--- a/hardware/setup/FX609/snap_FX609.xdc
+++ b/hardware/setup/FX609/snap_FX609.xdc
@@ -20,9 +20,6 @@
 
 create_clock -name sys_clk -period 10 [get_ports pcie_clkp]
 
-set_property LOC [get_package_pins -of_objects [get_bels [get_sites -filter {NAME =~ *COMMON*} -of_objects [get_iobanks -of_objects [get_sites GTYE4_COMMON_X1Y6]]]/REFCLK1P]] [get_ports pcie_clkp]
-set_property LOC [get_package_pins -of_objects [get_bels [get_sites -filter {NAME =~ *COMMON*} -of_objects [get_iobanks -of_objects [get_sites GTYE4_COMMON_X1Y6]]]/REFCLK1N]] [get_ports pcie_clkn]
-
 set_false_path -from [get_ports pcie_rst_n]
 
 set_max_delay -datapath_only -from [get_clocks -of_objects [get_nets c0/U0/pcihip0_psl_clk]] -to [get_clocks -of_objects [get_nets c0/U0/psl_clk]]         4.000

--- a/hardware/setup/S241/snap_S241.xdc
+++ b/hardware/setup/S241/snap_S241.xdc
@@ -20,9 +20,6 @@
 
 create_clock -name sys_clk -period 10 [get_ports pcie_clkp]
 
-set_property LOC [get_package_pins -of_objects [get_bels [get_sites -filter {NAME =~ *COMMON*} -of_objects [get_iobanks -of_objects [get_sites GTYE4_COMMON_X1Y6]]]/REFCLK1P]] [get_ports pcie_clkp]
-set_property LOC [get_package_pins -of_objects [get_bels [get_sites -filter {NAME =~ *COMMON*} -of_objects [get_iobanks -of_objects [get_sites GTYE4_COMMON_X1Y6]]]/REFCLK1N]] [get_ports pcie_clkn]
-
 set_false_path -from [get_ports pcie_rst_n]
 
 set_max_delay -datapath_only -from [get_clocks -of_objects [get_nets c0/U0/pcihip0_psl_clk]] -to [get_clocks -of_objects [get_nets c0/U0/psl_clk]]         4.000


### PR DESCRIPTION
Signed-off-by: luyong6 <luyong@cn.ibm.com>