### PR TITLE
Save make framework time by using -no_script

### DIFF
--- a/hardware/setup/create_framework.tcl
+++ b/hardware/setup/create_framework.tcl
@@ -179,59 +179,59 @@ if { $simulator != "nosim" } {
 # SNAP CORE IPs
 puts "                        importing IPs"
 add_files -norecurse  $ip_dir/fifo_4x512/fifo_4x512.xci >> $log_file
-export_ip_user_files -of_objects  [get_files  "$ip_dir/fifo_4x512/fifo_4x512.xci"] -force >> $log_file
+export_ip_user_files -of_objects  [get_files  "$ip_dir/fifo_4x512/fifo_4x512.xci"] -no_script -sync -force >> $log_file
 add_files -norecurse  $ip_dir/fifo_8x512/fifo_8x512.xci >> $log_file
-export_ip_user_files -of_objects  [get_files  "$ip_dir/fifo_8x512/fifo_8x512.xci"] -force >> $log_file
+export_ip_user_files -of_objects  [get_files  "$ip_dir/fifo_8x512/fifo_8x512.xci"] -no_script -sync -force >> $log_file
 add_files -norecurse  $ip_dir/fifo_10x512/fifo_10x512.xci >> $log_file
-export_ip_user_files -of_objects  [get_files  "$ip_dir/fifo_10x512/fifo_10x512.xci"] -force >> $log_file
+export_ip_user_files -of_objects  [get_files  "$ip_dir/fifo_10x512/fifo_10x512.xci"] -no_script -sync -force >> $log_file
 add_files -norecurse  $ip_dir/fifo_513x512/fifo_513x512.xci >> $log_file
-export_ip_user_files -of_objects  [get_files  "$ip_dir/fifo_513x512/fifo_513x512.xci"] -force >> $log_file
+export_ip_user_files -of_objects  [get_files  "$ip_dir/fifo_513x512/fifo_513x512.xci"] -no_script -sync -force >> $log_file
 # DDR3 / BRAM IPs
 if { $fpga_card == "ADKU3" } {
   if { $bram_used == "TRUE" } {
     add_files -norecurse $ip_dir/axi_clock_converter/axi_clock_converter.xci >> $log_file
-    export_ip_user_files -of_objects  [get_files "$ip_dir/axi_clock_converter/axi_clock_converter.xci"] -force >> $log_file
+    export_ip_user_files -of_objects  [get_files "$ip_dir/axi_clock_converter/axi_clock_converter.xci"] -no_script -sync -force >> $log_file
     add_files -norecurse $ip_dir/block_RAM/block_RAM.xci >> $log_file
-    export_ip_user_files -of_objects  [get_files "$ip_dir/block_RAM/block_RAM.xci"] -force >> $log_file
+    export_ip_user_files -of_objects  [get_files "$ip_dir/block_RAM/block_RAM.xci"] -no_script -sync -force >> $log_file
   } elseif { $sdram_used == "TRUE" } {
     add_files -norecurse $ip_dir/axi_clock_converter/axi_clock_converter.xci >> $log_file
-    export_ip_user_files -of_objects  [get_files "$ip_dir/axi_clock_converter/axi_clock_converter.xci"] -force >> $log_file
+    export_ip_user_files -of_objects  [get_files "$ip_dir/axi_clock_converter/axi_clock_converter.xci"] -no_script -sync -force >> $log_file
     add_files -norecurse $ip_dir/ddr3sdram/ddr3sdram.xci >> $log_file
-    export_ip_user_files -of_objects  [get_files "$ip_dir/ddr3sdram/ddr3sdram.xci"] -force >> $log_file
+    export_ip_user_files -of_objects  [get_files "$ip_dir/ddr3sdram/ddr3sdram.xci"] -no_script -sync -force >> $log_file
   }
 } elseif { ($fpga_card == "S121B") || ($fpga_card == "AD8K5") || ($fpga_card == "RCXVUP") || ($fpga_card == "FX609") || ($fpga_card == "S241") } {
   if { $bram_used == "TRUE" } {
     add_files -norecurse $ip_dir/axi_clock_converter/axi_clock_converter.xci >> $log_file
-    export_ip_user_files -of_objects  [get_files "$ip_dir/axi_clock_converter/axi_clock_converter.xci"] -force >> $log_file
+    export_ip_user_files -of_objects  [get_files "$ip_dir/axi_clock_converter/axi_clock_converter.xci"] -no_script -sync -force >> $log_file
     add_files -norecurse $ip_dir/block_RAM/block_RAM.xci >> $log_file
-    export_ip_user_files -of_objects  [get_files "$ip_dir/block_RAM/block_RAM.xci"] -force >> $log_file
+    export_ip_user_files -of_objects  [get_files "$ip_dir/block_RAM/block_RAM.xci"] -no_script -sync -force >> $log_file
   } elseif { $sdram_used == "TRUE" } {
     add_files -norecurse $ip_dir/axi_clock_converter/axi_clock_converter.xci >> $log_file
-    export_ip_user_files -of_objects  [get_files "$ip_dir/axi_clock_converter/axi_clock_converter.xci"] -force >> $log_file
+    export_ip_user_files -of_objects  [get_files "$ip_dir/axi_clock_converter/axi_clock_converter.xci"] -no_script -sync -force >> $log_file
     add_files -norecurse $ip_dir/ddr4sdram/ddr4sdram.xci >> $log_file
-    export_ip_user_files -of_objects  [get_files "$ip_dir/ddr4sdram/ddr4sdram.xci"] -force >> $log_file
+    export_ip_user_files -of_objects  [get_files "$ip_dir/ddr4sdram/ddr4sdram.xci"] -no_script -sync -force >> $log_file
   }
 } elseif { ($fpga_card == "N250S") || ($fpga_card == "N250SP") } {
   if { $bram_used == "TRUE" } {
     if { $nvme_used == "TRUE" } {
       add_files -norecurse $ip_dir/axi_interconnect/axi_interconnect.xci >> $log_file
-      export_ip_user_files -of_objects  [get_files "$ip_dir/axi_interconnect/axi_interconnect.xci"] -force >> $log_file
+      export_ip_user_files -of_objects  [get_files "$ip_dir/axi_interconnect/axi_interconnect.xci"] -no_script -sync -force >> $log_file
     } else {
       add_files -norecurse $ip_dir/axi_clock_converter/axi_clock_converter.xci >> $log_file
-      export_ip_user_files -of_objects  [get_files "$ip_dir/axi_clock_converter/axi_clock_converter.xci"] -force >> $log_file
+      export_ip_user_files -of_objects  [get_files "$ip_dir/axi_clock_converter/axi_clock_converter.xci"] -no_script -sync -force >> $log_file
     }
     add_files -norecurse $ip_dir/block_RAM/block_RAM.xci >> $log_file
-    export_ip_user_files -of_objects  [get_files "$ip_dir/block_RAM/block_RAM.xci"] -force >> $log_file
+    export_ip_user_files -of_objects  [get_files "$ip_dir/block_RAM/block_RAM.xci"] -no_script -sync -force >> $log_file
   } elseif { $sdram_used == "TRUE" } {
     if { $nvme_used == "TRUE" } {
       add_files -norecurse $ip_dir/axi_interconnect/axi_interconnect.xci >> $log_file
-      export_ip_user_files -of_objects  [get_files "$ip_dir/axi_interconnect/axi_interconnect.xci"] -force >> $log_file
+      export_ip_user_files -of_objects  [get_files "$ip_dir/axi_interconnect/axi_interconnect.xci"] -no_script -sync -force >> $log_file
     } else {
       add_files -norecurse $ip_dir/axi_clock_converter/axi_clock_converter.xci >> $log_file
-      export_ip_user_files -of_objects  [get_files "$ip_dir/axi_clock_converter/axi_clock_converter.xci"] -force >> $log_file
+      export_ip_user_files -of_objects  [get_files "$ip_dir/axi_clock_converter/axi_clock_converter.xci"] -no_script -sync -force >> $log_file
     }
     add_files -norecurse $ip_dir/ddr4sdram/ddr4sdram.xci >> $log_file
-    export_ip_user_files -of_objects  [get_files "$ip_dir/ddr4sdram/ddr4sdram.xci"] -force >> $log_file
+    export_ip_user_files -of_objects  [get_files "$ip_dir/ddr4sdram/ddr4sdram.xci"] -no_script -sync -force >> $log_file
   }
 }
 # User IPs
@@ -240,7 +240,7 @@ foreach usr_ip [glob -nocomplain -dir $usr_ip_dir *] {
   puts "                        importing user IP $usr_ip_name"
   set usr_ip_xci [glob -dir $usr_ip *.xci]
   add_files -norecurse $usr_ip_xci >> $log_file
-  export_ip_user_files -of_objects  [get_files "$usr_ip_xci"] -force >> $log_file
+  export_ip_user_files -of_objects  [get_files "$usr_ip_xci"] -no_script -sync -force >> $log_file
 }
 
 # Add NVME
@@ -249,7 +249,7 @@ if { $nvme_used == TRUE } {
   set_property  ip_repo_paths $hdl_dir/nvme/ [current_project]
   update_ip_catalog  >> $log_file
   add_files -norecurse                          $ip_dir/nvme/nvme.srcs/sources_1/bd/nvme_top/nvme_top.bd  >> $log_file
-  export_ip_user_files -of_objects  [get_files  $ip_dir/nvme/nvme.srcs/sources_1/bd/nvme_top/nvme_top.bd] -lib_map_path [list {{ies=$root_dir/viv_project/framework.cache/compile_simlib/ies}}] -force -quiet
+  export_ip_user_files -of_objects  [get_files  $ip_dir/nvme/nvme.srcs/sources_1/bd/nvme_top/nvme_top.bd] -lib_map_path [list {{ies=$root_dir/viv_project/framework.cache/compile_simlib/ies}}] -no_script -sync -force -quiet
 
   if { $denali_used == TRUE } {
     puts "                        adding NVMe Denali simulation files"
@@ -278,7 +278,7 @@ if { ($capi_ver == "capi20") && [file exists $capi_bsp_dir/capi_bsp_wrap.xcix] }
   update_ip_catalog >> $log_file
 
   add_files -norecurse                  $capi_bsp_dir/capi_bsp_wrap.xcix -force >> $log_file
-  export_ip_user_files -of_objects      [get_files capi_bsp_wrap.xci] -force >> $log_file
+  export_ip_user_files -of_objects      [get_files capi_bsp_wrap.xci] -no_script -sync -force >> $log_file
   set_property used_in_simulation false [get_files capi_bsp_wrap.xci] >> $log_file
 } elseif { ($capi_ver == "capi10") && ($psl_dcp != "FALSE") } {
   puts "                        importing PSL design checkpoint"


### PR DESCRIPTION
Signed-off-by: luyong6 <luyong@cn.ibm.com>

Generating scripts is time-consuming and doesn't help. I have verified it with simulation and make image. It doesn't have an impact. Please check (especially for nvme case because I didn't do it.) 

This can save the time in [CREATE_FRAMEWORK....]
