### PR TITLE
Add mechanism to specify HLS compiler flags in action hw Makefile

### DIFF
--- a/actions/hls.mk
+++ b/actions/hls.mk
@@ -27,6 +27,8 @@ endif
 
 PART_NUMBER ?= $(FPGACHIP)
 
+HLS_CFLAGS ?= ""
+
 # The wrapper name must match a function in the HLS sources which is
 # taken as entry point for the HDL generation.
 WRAPPER ?= hls_action
@@ -56,7 +58,8 @@ run_hls_script.tcl: $(SNAP_ROOT)/actions/scripts/create_run_hls_script.sh
 		-w $(WRAPPER)			\
 		-p $(PART_NUMBER)		\
 		-f "$(srcs)" 			\
-		-s $(SNAP_ROOT) > $@
+		-s $(SNAP_ROOT) 		\
+		-x $(HLS_CFLAGS) > $@
 
 $(SOLUTION_NAME): $(objs)
 	$(CXX) -o $@ $^

--- a/actions/scripts/create_run_hls_script.sh
+++ b/actions/scripts/create_run_hls_script.sh
@@ -45,6 +45,7 @@ function usage() {
   echo "    [-c <clock_period>]  HLS clock period."
   echo "    [-f <files>]         files to be used."
   echo "    [-s <snap_root>]     snap root directory."
+  echo "    [-x <cflags>]        extra HLS CFLAGS."
   echo "    [-V] Print program version (${version})"
   echo "    [-h] Print this help message."
   echo "    <path-to-bit-file>"
@@ -54,7 +55,7 @@ function usage() {
 }
 
 # Parse any options given on the command line
-while getopts ":n:d:w:p:c:f:s:Vh" opt; do
+while getopts ":n:d:w:p:c:f:s:x:Vh" opt; do
   case ${opt} in
       n)
       name=$OPTARG
@@ -76,6 +77,9 @@ while getopts ":n:d:w:p:c:f:s:Vh" opt; do
       ;;
       s)
       snap_root=$OPTARG
+      ;;
+      x)
+      cflags=$OPTARG
       ;;
       V)
       echo "${version}" >&2
@@ -107,8 +111,8 @@ set_top ${wrapper}
 
 # Can that be a list?
 foreach file [ list ${files} ] {
-  add_files \${file} -cflags "-I$snap_root/actions/include -I$snap_root/software/include -I../../../software/examples -I../include"
-  add_files -tb \${file} -cflags "-DNO_SYNTH -I$snap_root/actions/include -I$snap_root/software/include -I../../../software/examples -I../include"
+  add_files \${file} -cflags "$cflags -I$snap_root/actions/include -I$snap_root/software/include -I../../../software/examples -I../include"
+  add_files -tb \${file} -cflags "$cflags -DNO_SYNTH -I$snap_root/actions/include -I$snap_root/software/include -I../../../software/examples -I../include"
 }
 
 open_solution "${name}"


### PR DESCRIPTION
I'm using defines in my HLS code to conditionally enable specific behavior.
In order to automatically enable this behavior in my CI system, I'd like to be able to pass compiler flags to HLS when `make`ing the action's hardware part.

This PR adds the necessary variables to the `create_run_hls_script.tcl` which is responsible for creating the HLS project, thereby specifying the compiler flags associated with each file.