### PR TITLE
hdl_helloworld/create_action_ip: Configure IP to not require OOC run

### DIFF
--- a/actions/hdl_helloworld/ip/create_action_ip.tcl
+++ b/actions/hdl_helloworld/ip/create_action_ip.tcl
@@ -23,6 +23,7 @@ create_project action_ip_prj $aip_dir/action_ip_prj -force -part $fpga_part -ip 
 puts "                        Generating fifo_sync_32_512i512o ......"
 create_ip -name fifo_generator -vendor xilinx.com -library ip -version 13.2 -module_name fifo_sync_32_512i512o  >> $log_file
 set_property -dict [list  CONFIG.Fifo_Implementation {Common_Clock_Block_RAM} CONFIG.Input_Data_Width {512} CONFIG.Input_Depth {32} CONFIG.Output_Data_Width {512} CONFIG.Output_Depth {32} CONFIG.Use_Embedded_Registers {false} CONFIG.Reset_Type {Asynchronous_Reset} CONFIG.Full_Flags_Reset_Value {1} CONFIG.Valid_Flag {true} CONFIG.Data_Count {true} CONFIG.Data_Count_Width {5} CONFIG.Write_Data_Count_Width {5} CONFIG.Read_Data_Count_Width {5} CONFIG.Full_Threshold_Assert_Value {30} CONFIG.Full_Threshold_Negate_Value {29} CONFIG.Enable_Safety_Circuit {true}] [get_ips fifo_sync_32_512i512o]
+set_property generate_synth_checkpoint false [get_files $src_dir/fifo_sync_32_512i512o/fifo_sync_32_512i512o.xci] >> $log_file
 generate_target all [get_files $src_dir/fifo_sync_32_512i512o/fifo_sync_32_512i512o.xci] >> $log_file
 
 close_project


### PR DESCRIPTION
If IP is configured for OOC runs (default) but none is created later on, synthesis fails.

Signed-off-by: David Epping <david.epping@missinglinkelectronics.com>