### PR TITLE
Remove NVME option from menu for N250SP

### DIFF
--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -54,6 +54,7 @@ choice
        config N250SP
 		bool "CAPI2.0: Nallatech 250S+ with 4GB DDR4 SDRAM, NVMe and Xilinx KU15P FPGA"
 		select CAPI20
+		select DISABLE_NVME
 		help
 		  Nallatech 250S+ card originally used for CAPI Flash using NVMe
 		  storage. Uses Xilinx FPGA.
@@ -169,9 +170,6 @@ choice
 		  Please remember to set the environment variable "ACTION_ROOT"
 		  in snap_env.sh to the directory of the action source code.
 
-        config HDL_EXAMPLE
-                bool "HDL Example"
-
 	config HDL_HELLOWORLD
 		bool "HDL HelloWorld (Minimum example written in Verilog)"
                 help
@@ -179,6 +177,9 @@ choice
                     SNAP String Match (Regular Expression Match) Tool
                 select DISABLE_SDRAM_AND_BRAM
                 select DISABLE_NVME
+
+        config HDL_EXAMPLE
+                bool "HDL Example"
 
 	config HDL_NVME_EXAMPLE
 		bool "HDL NVMe Example"
@@ -195,7 +196,7 @@ choice
 		  in snap_env.sh to the directory of the action source code.
 
 	config HLS_HELLOWORLD
-		bool "HLS HelloWorld"
+		bool "HLS HelloWorld (Minimum example written in C)"
 		help
 		  This is the simplest example to start with:
 		  - Reading text from the server memory


### PR DESCRIPTION
NVME shouldn't be selectable on N250SP until it is fully enabled and tested
Signed-off-by: Bruno Mesnet <bruno.mesnet@fr.ibm.com>