### PR TITLE
Keep previously specified IP repo paths when adding NVMe block design

### DIFF
--- a/actions/hls.mk
+++ b/actions/hls.mk
@@ -83,7 +83,7 @@ run_hls_script.tcl: $(SNAP_ROOT)/actions/scripts/create_run_hls_script.sh
 		-c $(HLS_ACTION_CLOCK)		\
 		-f "$(srcs)" 			\
 		-s $(SNAP_ROOT) 		\
-		-x $(HLS_CFLAGS) > $@
+		-x "$(HLS_CFLAGS)" > $@
 
 $(SOLUTION_NAME): $(objs)
 	$(CXX) -o $@ $^

--- a/hardware/setup/create_framework.tcl
+++ b/hardware/setup/create_framework.tcl
@@ -210,7 +210,7 @@ foreach ip_xci [glob -nocomplain -dir $action_ip_dir */*.xci] {
 # Add NVME
 if { $nvme_used == TRUE } {
   puts "                        adding NVMe block design"
-  set_property  ip_repo_paths $hdl_dir/nvme/ [current_project]
+  set_property  ip_repo_paths [concat [get_property ip_repo_paths [current_project]] $hdl_dir/nvme/] [current_project]
   update_ip_catalog  >> $log_file
   add_files -norecurse                          $ip_dir/nvme/nvme.srcs/sources_1/bd/nvme_top/nvme_top.bd  >> $log_file
   export_ip_user_files -of_objects  [get_files  $ip_dir/nvme/nvme.srcs/sources_1/bd/nvme_top/nvme_top.bd] -lib_map_path [list {{ies=$root_dir/viv_project/framework.cache/compile_simlib/ies}}] -no_script -sync -force -quiet


### PR DESCRIPTION
This fixes a small issue where IP repository paths set by a custom tcl script during action build are getting overwritten by the create_framework.tcl when adding the NVMe components to the project.