### PR TITLE
Add Metal FS Action Type

### DIFF
--- a/ActionTypes.md
+++ b/ActionTypes.md
@@ -23,6 +23,7 @@ IBM | 10.14.10.0C | 10.14.10.0C | HLS Scatter-Gather
 IBM | 10.14.10.0D | 10.14.FF.FF | Reserved for IBM Actions
 MLE | 22.DB.00.01 | 22.DB.00.01 | HDL 10G Ethernet TCP/UDP/IP Accelerator Demo
 MLE | 22.DB.00.02 | 22.DB.00.02 | HDL 25G Ethernet TCP/UDP/IP Accelerator Demo
+HPI | FB.06.00.01 | FB.06.00.01 | Metal FS
 Reserved | FF.FF.00.00 | FF.FF.FF.FF | Reserved
 
 ### How to apply for a new Action Type


### PR DESCRIPTION
This adds Metal FS to the list of known Action Types, under the FB.06 vendor namespace.