### PR TITLE
Add make target for simulating in tmux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ help:
 	@echo "* hardware       Build simulation model and FPGA bitstream (combines targets 'model' and 'image')";
 	@echo "* hw_project     Create Vivado project";
 	@echo "* sim            Start a simulation";
-	@echo "* sim_screen     Start a simulation in screen";
+	@echo "* sim_tmux       Start a simulation in tmux";
 	@echo "* software       Build software libraries and tools for SNAP";
 	@echo "* apps           Build the applications for all actions";
 	@echo "* clean          Remove all files generated in make process";
@@ -105,7 +105,7 @@ $(hardware_subdirs): $(snap_env_sh)
 hardware: $(hardware_subdirs)
 
 # Model build and config
-hw_project model sim image cloud_enable cloud_base cloud_action sim_screen: $(snap_env_sh)
+hw_project model sim image cloud_enable cloud_base cloud_action sim_tmux: $(snap_env_sh)
 	@for dir in $(hardware_subdirs); do                \
 	    if [ -d $$dir ]; then                          \
 	        $(MAKE) -s -C $$dir $@ || exit 1;          \

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ help:
 	@echo "* hardware       Build simulation model and FPGA bitstream (combines targets 'model' and 'image')";
 	@echo "* hw_project     Create Vivado project";
 	@echo "* sim            Start a simulation";
+	@echo "* sim_screen     Start a simulation in screen";
 	@echo "* software       Build software libraries and tools for SNAP";
 	@echo "* apps           Build the applications for all actions";
 	@echo "* clean          Remove all files generated in make process";
@@ -104,7 +105,7 @@ $(hardware_subdirs): $(snap_env_sh)
 hardware: $(hardware_subdirs)
 
 # Model build and config
-hw_project model sim image cloud_enable cloud_base cloud_action: $(snap_env_sh)
+hw_project model sim image cloud_enable cloud_base cloud_action sim_screen: $(snap_env_sh)
 	@for dir in $(hardware_subdirs); do                \
 	    if [ -d $$dir ]; then                          \
 	        $(MAKE) -s -C $$dir $@ || exit 1;          \

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -468,8 +468,8 @@ sim: check_simulator
 	@if [ "$(SIMULATOR)" != "nosim" ]; then cd sim; ./run_sim; fi
 	@echo -e "[SIMULATION........] done  `date +"%T %a %b %d %Y"`"
 
-sim_screen:
-	@screen $(MAKE) -s sim
+sim_tmux:
+	@tmux new-session $(MAKE) -s sim
 
 else #noteq ($(PLATFORM),x86_64)
 .PHONY: wrong_platform all model sim image

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -469,7 +469,7 @@ sim: check_simulator
 	@echo -e "[SIMULATION........] done  `date +"%T %a %b %d %Y"`"
 
 sim_tmux:
-	@tmux new-session $(MAKE) -s sim
+	@tmux new-session "$(MAKE) -s sim"
 
 else #noteq ($(PLATFORM),x86_64)
 .PHONY: wrong_platform all model sim image

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -468,6 +468,9 @@ sim: check_simulator
 	@if [ "$(SIMULATOR)" != "nosim" ]; then cd sim; ./run_sim; fi
 	@echo -e "[SIMULATION........] done  `date +"%T %a %b %d %Y"`"
 
+sim_screen:
+	@screen $(MAKE) -s sim
+
 else #noteq ($(PLATFORM),x86_64)
 .PHONY: wrong_platform all model sim image
 

--- a/hardware/sim/run_sim
+++ b/hardware/sim/run_sim
@@ -372,7 +372,7 @@
           screen -S $STY -X screen
 
           screen_pid=$(echo $STY | awk '{print strtonum($1)}')
-          shell_pid=$(ps --ppid $screen_pid -ho pid | tail -n1)
+          shell_pid=$(ps --ppid $screen_pid -ho pid | tail -n1 | awk '{$1=$1};1')
 
           # Wait for the shell to exit (not a direct child process)
           tail --pid=$shell_pid -f /dev/null &

--- a/hardware/sim/run_sim
+++ b/hardware/sim/run_sim
@@ -54,7 +54,7 @@
  runsim_args=$@
  while [[ $# > 0 ]]; do         # consume multiple args per loop with shift
 #  echo "arg1=$1 arg2=$2"
-   case $1 in				
+   case $1 in
      xsim|irun|questa|modelsim|xcelium)   SIM_OVER="$1";;
      -xsim)             SIM_OVER="xsim";;
      -irun)             SIM_OVER="irun";;
@@ -66,25 +66,25 @@
      -list)		TST_NAME='LIST';LISTNAME="$2";shift
      			if [[ ! -f ${SNAP_ROOT}/hardware/sim/${LISTNAME} ]];then echo "testlist ${SNAP_ROOT}/hardware/sim/${LISTNAME} not found, leaving"; exit 11; fi;;
      -x|xterm|XTERM)	TST_NAME='XTERM';;
-     -quiet)		VERBOSE="";;	
-     -verbose)		VERBOSE="-vvv";;	
-     -v1|-v)		VERBOSE="-v";;		
-     -v2|-vv)		VERBOSE="-vv";;	
-     -v3|-vvv)		VERBOSE="-vvv";;	
-     -v4|-vvvv)		VERBOSE="-vvvv";;	
-     -v5|-vvvvv)	VERBOSE="-vvvvv";;	
+     -quiet)		VERBOSE="";;
+     -verbose)		VERBOSE="-vvv";;
+     -v1|-v)		VERBOSE="-v";;
+     -v2|-vv)		VERBOSE="-vv";;
+     -v3|-vvv)		VERBOSE="-vvv";;
+     -v4|-vvvv)		VERBOSE="-vvvv";;
+     -v5|-vvvvv)	VERBOSE="-vvvvv";;
      -v6|-vvvvvv)	VERBOSE="-vvvvvv";;	# can lead to files >1GB
-     -clean)		CLEAN=1;;	
-     -keep)		CLEAN=0;;	
-     -local)		LOCAL=1;;	
+     -clean)		CLEAN=1;;
+     -keep)		CLEAN=0;;
+     -local)		LOCAL=1;;
      -explore)		EXPLORE=1;;
-     -inject)		TCL_INJECT=1;;	
-     -seed)		TCL_SEED="$2";shift;;	
+     -inject)		TCL_INJECT=1;;
+     -seed)		TCL_SEED="$2";shift;;
      -rndmask)		RNDMASK=1;;
-     -tn)		TSTNUM="$2";shift;;	
-     -par)		PAR="$2";shift;;	
-     -t)		TST_TITLE="$2";shift;;	
-     -p)		PARM_FILE="$2";shift;;	
+     -tn)		TSTNUM="$2";shift;;
+     -par)		PAR="$2";shift;;
+     -t)		TST_TITLE="$2";shift;;
+     -p)		PARM_FILE="$2";shift;;
      -arg)		TST_ARG="${TST_ARG} $2";shift;;
      -aet)		AET=1;;
      -noaet)		AET=0;;
@@ -255,7 +255,7 @@
    fi
    if [ "$LOCAL" == "1" ];then
      `sed -i "s/-incfiles/;#-incfiles/g" ncaet.tcl`				# no AET size limit locally
-   else                                                   	
+   else
      `sed -i "s/;#-incfiles/-incfiles/g" ncaet.tcl`				# limit AET size for AFS
    fi
    if [ "$TCL_SEED" != "0" ];then
@@ -364,17 +364,17 @@
      prc[$i]=0
      if [ "$PAR" == "1" ];then STIMLOG="stim.log";else STIMLOG="stim${i}.log";fi
      if [ "$TST_NAME" == "XTERM" ];then
-        if [ -z "$STY" ];then
+        if [ -z "$TMUX" ];then
           xterm -title "testcase window, use >script ${STIMLOG}< to log input" & 	# tee+RC doesnt work here, use script instead
         else
-          # Running inside a screen session
-          screen -S $STY -X chdir $SIMBASE/$SIMDIR/$SIMOUT
-          screen -S $STY -X screen
+          # Running inside a tmux session
+          tmux new-window -c $SIMBASE/$SIMDIR/$SIMOUT
+          tmux send-keys ". $SNAP_ROOT/snap_path.sh" Enter
 
-          screen_pid=$(echo $STY | awk '{print strtonum($1)}')
-          shell_pid=$(ps --ppid $screen_pid -ho pid | tail -n1 | awk '{$1=$1};1')
+          shell_pid=$(tmux list-panes -F '#{pane_pid}')
 
           # Wait for the shell to exit (not a direct child process)
+          echo "tail --pid=$shell_pid -f /dev/null &"
           tail --pid=$shell_pid -f /dev/null &
         fi
      elif [ "$TST_NAME" == "LIST" ];then
@@ -423,7 +423,7 @@
          pid[$i]="0";ts1=$(date +%s); 				# dont wait for this pid anymore, start new timer
        fi
      done
-     if [[ "$num" == "0" ]];then echo "execution finished"|tee -a stim.log; break; fi	
+     if [[ "$num" == "0" ]];then echo "execution finished"|tee -a stim.log; break; fi
      if [[ "${array[@]}" == *"$SIM_PID"* ]];then missing="0";
      else missing="1";echo "$SIMULATOR not running anymore"|tee -a stim.log;
      fi
@@ -447,7 +447,7 @@
      fi
      if [[ "$num" -lt 3 ]];then					# no app process, leave the loop
        echo "execution finished,remaining pid=${pid[@]}"|tee -a stim.log; break;
-     fi	
+     fi
      sleep 5;
    done
    if [ "$PAR" -ne "1" ] ;then					# generate Runtime timestamp, in case you dont have one
@@ -492,7 +492,7 @@
    if [ "$AET" == "1" ];then $PSLSE_ROOT/debug/debug >debug.lst;fi # assume you need debug info
  else PSLSEVERS="N/A"
  fi
- if [ "$PAR" -ne "1" ] ;then	
+ if [ "$PAR" -ne "1" ] ;then
    EXECUTED=`grep --text 'executed\.' stim1.log|tail -n1|awk '{print $1}'`
    FAILED=`grep   --text 'executed\.' stim1.log|tail -n1|awk '{print $4}'`
  else
@@ -502,16 +502,16 @@
  RUNTIME=`grep --text 'Runtime:'   stim.log|tail -n1|awk '{print $3}'`
  SIMTIME=`grep --text 'Simulation complete via' sim.log|sed 's/\(.* at time\)\(.*\)\(\+.*\)/\2/'|sed 's/ //g'`
  SPEED=`cat /proc/cpuinfo|grep -i mhz|tail -n 1|sed 's/\./ /g'|awk '{print $4}'`
- CPUS=`cat /proc/cpuinfo|grep processor|wc -l`			
+ CPUS=`cat /proc/cpuinfo|grep processor|wc -l`
  LOAD=`uptime|awk '{print $12}'|sed 's/,/ /g'`	# remove eventual commas
  if [ "$LOCAL" == "1" ];then
    PERCUSED=`df -k 2>/dev/null|grep '\/data'|tail -n1|awk '{print $5}'`
  else
    afs_exist=`df -k 2>/dev/null|grep AFS|wc -l`; if [ "$afs_exist" == "1" ];then
-     PERCUSED=`fs lq |tail -n1|awk '{print $4}'`	
+     PERCUSED=`fs lq |tail -n1|awk '{print $4}'`
    else PERCUSED="N/A";fi
  fi
- USED=`du -sk . |awk '{print $1}'`				
+ USED=`du -sk . |awk '{print $1}'`
  echo "**** RC=$TCRC parallel=$PAR executed=$EXECUTED failed=$FAILED runtime=$RUNTIME simtime=$SIMTIME cpus=$CPUS speed=$SPEED load=$LOAD local=$LOCAL used_kB=$USED percused=$PERCUSED"
 #echo "**** Versions: HW=$HWVERS SW=$SWVERS PSLSE=$PSLSEVERS"
  echo "**** Versions: SNAP=$SNAPVERS PSLSE=$PSLSEVERS"

--- a/hardware/sim/run_sim
+++ b/hardware/sim/run_sim
@@ -364,7 +364,19 @@
      prc[$i]=0
      if [ "$PAR" == "1" ];then STIMLOG="stim.log";else STIMLOG="stim${i}.log";fi
      if [ "$TST_NAME" == "XTERM" ];then
-       xterm -title "testcase window, use >script ${STIMLOG}< to log input" & 	# tee+RC doesnt work here, use script instead
+        if [ -z "$STY" ];then
+          xterm -title "testcase window, use >script ${STIMLOG}< to log input" & 	# tee+RC doesnt work here, use script instead
+        else
+          # Running inside a screen session
+          screen -S $STY -X chdir $SIMBASE/$SIMDIR/$SIMOUT
+          screen -S $STY -X screen
+
+          screen_pid=$(echo $STY | awk '{print strtonum($1)}')
+          shell_pid=$(ps --ppid $screen_pid -ho pid | tail -n1)
+
+          # Wait for the shell to exit (not a direct child process)
+          tail --pid=$shell_pid -f /dev/null &
+        fi
      elif [ "$TST_NAME" == "LIST" ];then
        filename="${LISTNAME%.*}"; parfilename="${LISTNAME%.*}${i}";echo "listname=${LISTNAME}"|tee -a stim.log
         if [ -f "${parfilename}.sh" ];then


### PR DESCRIPTION
When developing on a remote machine (i.e. using an SSH connection) it's not possible to run the SNAP simulation because it opens a new xterm window.

As an alternative, I have added another target to the root Makefile that allows to use the terminal multiplexer 'screen' instead. If users prefer to use that over the xterm simulator window, they can install screen on their machine and use `make sim_screen` for simulation.