### PR TITLE
Make software.mk to clean object files more thoroughly

### DIFF
--- a/actions/software.mk
+++ b/actions/software.mk
@@ -98,5 +98,5 @@ uninstall:
 	done
 
 clean distclean:
-	$(RM) $(projs) $(libs) *.o *.log *.out *~
+	$(RM) $(projs) $(libs) *.o $($(projs)_objs) *.log *.out *~
 


### PR DESCRIPTION
Currently most sw directories of actions do not have any sub-directories and therefore software.mk is also only erasing the object files created in single depth of sw. This patch allows users to erase any object files in sub-directories of sw with make clean command if they have properly set $(projs)_objs argument.