### PR TITLE
AD9H3 subdevice corrected

### DIFF
--- a/software/tools/snap_find_card
+++ b/software/tools/snap_find_card
@@ -219,7 +219,7 @@ while getopts ":vA:C:Vh" opt; do
 		if [ $? == 1 ]; then
 			exit 1
 		fi
-                detect_card_name $card  "0x0632" "0x0676" "AD9H3"
+                detect_card_name $card  "0x0632" "0x0667" "AD9H3"
                 if [ $? == 1 ]; then
                         exit 1
                 fi


### PR DESCRIPTION
Signed-off-by: Alexandre CASTELLANE <alexandre.castellane@fr.ibm.com>